### PR TITLE
fix: make Bind trait accessible

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -9,13 +9,14 @@ use hyper::{
 use serde::Deserialize;
 use url::Url;
 
+pub use crate::sql_builder::Bind;
 use crate::{
     buflist::BufList,
     error::{Error, Result},
     introspection::Reflection,
     response::Response,
     rowbinary,
-    sql_builder::{Bind, SqlBuilder},
+    sql_builder::SqlBuilder,
     Client,
 };
 


### PR DESCRIPTION
Rationale:
`Bind` trait is used in public interface, can't be used outside since it's declared in private module `sql_builder`. Making `sql_builder` doesn't seem reasonable, so I decided to reexport it in module `query` where it's used.