### PR TITLE
Use Rust `cityhash-rs` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default = ["lz4"]
 test-util = ["hyper/server"]
 
 # Compression
-lz4 = ["lz4-sys", "clickhouse-rs-cityhash-sys"]
+lz4 = ["lz4-sys", "cityhash-rs"]
 gzip = ["async-compression", "async-compression/gzip", "tokio-util"]
 zlib = ["async-compression", "async-compression/zlib", "tokio-util"]
 brotli = ["async-compression", "async-compression/brotli", "tokio-util"]
@@ -56,7 +56,7 @@ async-compression = { version = "0.3.6", features = ["tokio"], optional = true }
 tokio-util = { version = "0.6.0", default-features = false, features = ["codec", "io"], optional = true }
 take_mut = "0.2.2"
 lz4-sys = { version = "1.9.2", optional = true }
-clickhouse-rs-cityhash-sys = { version = "0.1.2", optional = true }
+cityhash-rs = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.2"


### PR DESCRIPTION
This PR replaces the FFI call to the C implementation of cityhash with a pure Rust implementation in the `cityhash-rs` crate.