### PR TITLE
Use generic HTTP connector in Client

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,0 +1,42 @@
+use hyper::{
+    client::{connect::Connect, ResponseFuture},
+    Body, Request,
+};
+
+use crate::sealed::Sealed;
+
+pub type BoxHttpClient = Box<dyn HttpClient + Send + Sync + 'static>;
+
+pub trait HttpClient: Sealed + CloneBoxHttpClient {
+    fn _request(&self, req: Request<Body>) -> ResponseFuture;
+}
+
+impl<C> Sealed for hyper::Client<C> {}
+
+impl<C> HttpClient for hyper::Client<C>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
+    fn _request(&self, req: Request<Body>) -> ResponseFuture {
+        self.request(req)
+    }
+}
+
+pub trait CloneBoxHttpClient {
+    fn clone_box_http_client(&self) -> BoxHttpClient;
+}
+
+impl<T> CloneBoxHttpClient for T
+where
+    T: 'static + HttpClient + Clone + Send + Sync + 'static,
+{
+    fn clone_box_http_client(&self) -> BoxHttpClient {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for BoxHttpClient {
+    fn clone(&self) -> Self {
+        self.clone_box_http_client()
+    }
+}

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -5,9 +5,7 @@ use hyper::{
 
 use crate::sealed::Sealed;
 
-pub type BoxHttpClient = Box<dyn HttpClient + Send + Sync + 'static>;
-
-pub trait HttpClient: Sealed + CloneBoxHttpClient {
+pub trait HttpClient: Sealed + Send + Sync + 'static {
     fn _request(&self, req: Request<Body>) -> ResponseFuture;
 }
 
@@ -19,24 +17,5 @@ where
 {
     fn _request(&self, req: Request<Body>) -> ResponseFuture {
         self.request(req)
-    }
-}
-
-pub trait CloneBoxHttpClient {
-    fn clone_box_http_client(&self) -> BoxHttpClient;
-}
-
-impl<T> CloneBoxHttpClient for T
-where
-    T: 'static + HttpClient + Clone + Send + Sync + 'static,
-{
-    fn clone_box_http_client(&self) -> BoxHttpClient {
-        Box::new(self.clone())
-    }
-}
-
-impl Clone for BoxHttpClient {
-    fn clone(&self) -> Self {
-        self.clone_box_http_client()
     }
 }

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, marker::PhantomData, mem, panic};
 
 use bytes::BytesMut;
-use hyper::{self, body, Body, Request};
+use hyper::{self, body, client::connect::Connect, Body, Request};
 use serde::Serialize;
 use tokio::task::JoinHandle;
 use url::Url;
@@ -25,8 +25,9 @@ pub struct Insert<T> {
 }
 
 impl<T> Insert<T> {
-    pub(crate) fn new(client: &Client, table: &str) -> Result<Self>
+    pub(crate) fn new<C>(client: &Client<C>, table: &str) -> Result<Self>
     where
+        C: Connect + Clone + Send + Sync + 'static,
         T: Row,
     {
         let mut url = Url::parse(&client.url).expect("TODO");

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, marker::PhantomData, mem, panic};
 
 use bytes::BytesMut;
-use hyper::{self, body, client::connect::Connect, Body, Request};
+use hyper::{self, body, Body, Request};
 use serde::Serialize;
 use tokio::task::JoinHandle;
 use url::Url;
@@ -25,9 +25,8 @@ pub struct Insert<T> {
 }
 
 impl<T> Insert<T> {
-    pub(crate) fn new<C>(client: &Client<C>, table: &str) -> Result<Self>
+    pub(crate) fn new(client: &Client, table: &str) -> Result<Self>
     where
-        C: Connect + Clone + Send + Sync + 'static,
         T: Row,
     {
         let mut url = Url::parse(&client.url).expect("TODO");
@@ -63,7 +62,7 @@ impl<T> Insert<T> {
             .body(body)
             .map_err(|err| Error::InvalidParams(Box::new(err)))?;
 
-        let future = client.client.request(request);
+        let future = client.client._request(request);
         let handle =
             tokio::spawn(async move { Response::new(future, Compression::None).finish().await });
 

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -1,5 +1,6 @@
 use std::{future::Future, mem};
 
+use hyper::client::connect::Connect;
 use serde::Serialize;
 use tokio::time::{Duration, Instant};
 
@@ -10,8 +11,8 @@ const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(10);
 const MAX_TIME_BIAS: f64 = 0.10; // a fraction of `max_duration`
 
 #[must_use]
-pub struct Inserter<T> {
-    client: Client,
+pub struct Inserter<C, T> {
+    client: Client<C>,
     table: String,
     max_entries: u64,
     max_duration: Duration,
@@ -34,11 +35,12 @@ impl Quantities {
     };
 }
 
-impl<T> Inserter<T>
+impl<C, T> Inserter<C, T>
 where
+    C: Connect + Clone + Send + Sync + 'static,
     T: Row,
 {
-    pub(crate) fn new(client: &Client, table: &str) -> Result<Self> {
+    pub(crate) fn new(client: &Client<C>, table: &str) -> Result<Self> {
         Ok(Self {
             client: client.clone(),
             table: table.into(),

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -1,6 +1,5 @@
 use std::{future::Future, mem};
 
-use hyper::client::connect::Connect;
 use serde::Serialize;
 use tokio::time::{Duration, Instant};
 
@@ -11,8 +10,8 @@ const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(10);
 const MAX_TIME_BIAS: f64 = 0.10; // a fraction of `max_duration`
 
 #[must_use]
-pub struct Inserter<C, T> {
-    client: Client<C>,
+pub struct Inserter<T> {
+    client: Client,
     table: String,
     max_entries: u64,
     max_duration: Duration,
@@ -35,12 +34,11 @@ impl Quantities {
     };
 }
 
-impl<C, T> Inserter<C, T>
+impl<T> Inserter<T>
 where
-    C: Connect + Clone + Send + Sync + 'static,
     T: Row,
 {
-    pub(crate) fn new(client: &Client<C>, table: &str) -> Result<Self> {
+    pub(crate) fn new(client: &Client, table: &str) -> Result<Self> {
         Ok(Self {
             client: client.clone(),
             table: table.into(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,4 @@
 use hyper::{
-    client::connect::Connect,
     header::{ACCEPT_ENCODING, CONTENT_LENGTH},
     Body, Method, Request,
 };
@@ -19,13 +18,13 @@ const MAX_QUERY_LEN_TO_USE_GET: usize = 8192;
 
 #[must_use]
 #[derive(Clone)]
-pub struct Query<C> {
-    client: Client<C>,
+pub struct Query {
+    client: Client,
     sql: SqlBuilder,
 }
 
-impl<C> Query<C> where C: Connect + Clone + Send + Sync + 'static {
-    pub(crate) fn new(client: &Client<C>, template: &str) -> Self {
+impl Query {
+    pub(crate) fn new(client: &Client, template: &str) -> Self {
         Self {
             client: client.clone(),
             sql: SqlBuilder::new(template),
@@ -141,7 +140,7 @@ impl<C> Query<C> where C: Connect + Clone + Send + Sync + 'static {
             .body(body)
             .map_err(|err| Error::InvalidParams(Box::new(err)))?;
 
-        let future = self.client.client.request(request);
+        let future = self.client.client._request(request);
         Ok(Response::new(future, self.client.compression))
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,5 @@
 use hyper::{
+    client::connect::Connect,
     header::{ACCEPT_ENCODING, CONTENT_LENGTH},
     Body, Method, Request,
 };
@@ -18,13 +19,13 @@ const MAX_QUERY_LEN_TO_USE_GET: usize = 8192;
 
 #[must_use]
 #[derive(Clone)]
-pub struct Query {
-    client: Client,
+pub struct Query<C> {
+    client: Client<C>,
     sql: SqlBuilder,
 }
 
-impl Query {
-    pub(crate) fn new(client: &Client, template: &str) -> Self {
+impl<C> Query<C> where C: Connect + Clone + Send + Sync + 'static {
+    pub(crate) fn new(client: &Client<C>, template: &str) -> Self {
         Self {
             client: client.clone(),
             sql: SqlBuilder::new(template),


### PR DESCRIPTION
## Motivation

Need to connect to ClickHouse via TLS, but the `hyper::Client<HttpConnector>` used in `clickhouse::Client::default()` cannot handle `https://` URLs.

## Solution

1. Make `Client` generic over type param `C`, which should implement the `hyper::client::connect::Connect` trait.
2. Allow injection of `hyper::Client` via `with_hyper_client()`.

With these updates, users of `clickhouse::Client` can connect to ClickHouse via TLS with something like `hyper::Client<hyper_tls::HttpsConnector<HttpConnector>>`. For example:

```rust
let mut http_connector = HttpConnector::new();
http_connector.enforce_http(false); // allow https URLs

let tls_connector = native_tls::TlsConnector::builder().build()?.into();
let https_connector = HttpsConnector::from((http_connector, tls_connector));
let hyper_client = hyper::client::Client::builder().build(connector);

let client = clickhouse::Client::with_hyper_client(http).with_url("https://...");
```