### PR TITLE
Added HTTPS support (bis)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,14 @@ required-features = ["test-util"]
 debug = true
 
 [features]
-default = ["lz4"]
+default = ["lz4", "tls"]
 
 test-util = ["hyper/server"]
 watch = ["dep:sha-1", "dep:serde_json"]
 lz4 = ["dep:lz4", "dep:clickhouse-rs-cityhash-sys"]
 uuid = ["dep:uuid"]
 time = ["dep:time"]
+tls = ["dep:hyper-tls"]
 
 # Temporary workaround for https://github.com/ClickHouse/ClickHouse/issues/37420
 wa-37420 = []
@@ -49,6 +50,7 @@ serde = "1.0.106"
 bytes = "1"
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
 hyper = { version = "0.14", features = ["client", "tcp", "http1", "stream"] }
+hyper-tls = { version = "0.5.0", optional = true }
 url = "2.1.1"
 futures = "0.3.5"
 static_assertions = "1.1"


### PR DESCRIPTION
I took most of the code from #36 and wrapped it as suggested. Any reviews are welcome.

* Added 'tls' as default feature
* Added 'hyper-tls' as dependency for tls feature
* Now when setting up the client, if compiled with 'tls' feature, the `Client::with_url` method checks for urls that start with 'https:' and creates an `HttpsConnector` for the hyper client