### PR TITLE
feat(inserter): start new insert only when the first row is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Changed
+- inserter: start new insert only when the first row is provided ([#68]).
+
+[#68]: https://github.com/loyd/clickhouse.rs/pull/68
 
 ## [0.11.4] - 2023-05-14
 ### Added

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, mem};
+use std::mem;
 
 use serde::Serialize;
 use tokio::time::{Duration, Instant};
@@ -17,7 +17,7 @@ pub struct Inserter<T> {
     max_entries: u64,
     send_timeout: Option<Duration>,
     end_timeout: Option<Duration>,
-    insert: Insert<T>,
+    insert: Option<Insert<T>>,
     ticks: Ticks,
     committed: Quantities,
     uncommitted_entries: u64,
@@ -51,7 +51,7 @@ where
             max_entries: DEFAULT_MAX_ENTRIES,
             send_timeout: None,
             end_timeout: None,
-            insert: client.insert(table)?,
+            insert: None,
             ticks: Ticks::default(),
             committed: Quantities::ZERO,
             uncommitted_entries: 0,
@@ -116,7 +116,9 @@ where
     pub fn set_timeouts(&mut self, send_timeout: Option<Duration>, end_timeout: Option<Duration>) {
         self.send_timeout = send_timeout;
         self.end_timeout = end_timeout;
-        self.insert.set_timeouts(send_timeout, end_timeout);
+        if let Some(insert) = &mut self.insert {
+            insert.set_timeouts(self.send_timeout, self.end_timeout);
+        }
     }
 
     /// See [`Inserter::with_max_entries()`].
@@ -157,12 +159,19 @@ where
     /// # Panics
     /// If called after previous call returned an error.
     #[inline]
-    pub fn write<'a>(&'a mut self, row: &T) -> impl Future<Output = Result<()>> + 'a + Send
+    pub async fn write(&mut self, row: &T) -> Result<()>
     where
         T: Serialize,
     {
         self.uncommitted_entries += 1;
-        self.insert.write(row)
+        let insert = if let Some(insert) = &mut self.insert {
+            insert
+        } else {
+            let mut new_insert = self.client.insert(&self.table)?;
+            new_insert.set_timeouts(self.send_timeout, self.end_timeout);
+            self.insert.insert(new_insert)
+        };
+        insert.write(row).await
     }
 
     /// Checks limits and ends a current `INSERT` if they are reached.
@@ -189,8 +198,10 @@ where
     /// Ends a current `INSERT` and whole `Inserter` unconditionally.
     ///
     /// If it isn't called, the current `INSERT` is aborted.
-    pub async fn end(self) -> Result<Quantities> {
-        self.insert.end().await?;
+    pub async fn end(mut self) -> Result<Quantities> {
+        if let Some(insert) = self.insert.take() {
+            insert.end().await?;
+        }
         Ok(self.committed)
     }
 
@@ -200,9 +211,9 @@ where
     }
 
     async fn insert(&mut self) -> Result<()> {
-        let mut new_insert = self.client.insert(&self.table)?; // Actually it mustn't fail.
-        new_insert.set_timeouts(self.send_timeout, self.end_timeout);
-        let insert = mem::replace(&mut self.insert, new_insert);
-        insert.end().await
+        if let Some(insert) = self.insert.take() {
+            insert.end().await?;
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Benchmarks

No noticeable regression was detected.

```
$ critcmp master patch
group                    master                                 patch
-----                    ------                                 -----
insert/lz4               1.00    84.9±66.97ns   269.6 MB/sec    1.04    88.0±67.45ns   260.2 MB/sec
insert/lz4hc(4)          1.00    89.0±69.89ns   257.1 MB/sec    1.02    90.6±65.06ns   252.8 MB/sec
insert/no compression    1.00     38.0±5.62ns   603.0 MB/sec    1.03     39.1±7.13ns   585.3 MB/sec
```