### PR TITLE
Include options on inserts as well as queries

### DIFF
--- a/src/insert.rs
+++ b/src/insert.rs
@@ -78,6 +78,10 @@ impl<T> Insert<T> {
             pairs.append_pair("decompress", "1");
         }
 
+        for (name, value) in &client.options {
+            pairs.append_pair(name, value);
+        }
+
         drop(pairs);
 
         let mut builder = Request::post(url.as_str());


### PR DESCRIPTION
Commit 79f5ab48ad906948c6011ef0748678ebccfda9b3 added support for `with_option()` and this commit includes those options also in the URL of inserts.