### PR TITLE
Support rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ lz4 = ["dep:lz4", "dep:clickhouse-rs-cityhash-sys"]
 uuid = ["dep:uuid"]
 time = ["dep:time"]
 tls = ["dep:hyper-tls"]
+rustls = ["dep:hyper-rustls"]
 quanta = ["dep:quanta"]
 
 [dependencies]
@@ -51,6 +52,7 @@ thiserror = "1.0.16"
 serde = "1.0.106"
 bytes = "1"
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
+hyper-rustls = { version = "0.24", features = ["http2"], optional = true }
 hyper = { version = "0.14", features = ["client", "tcp", "http1", "stream"] }
 hyper-tls = { version = "0.5.0", optional = true }
 url = "2.1.1"

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ See [examples](https://github.com/loyd/clickhouse.rs/tree/master/examples).
 ## Feature Flags
 * `lz4` (enabled by default) — enables `Compression::Lz4` and `Compression::Lz4Hc(_)` variants. If enabled, `Compression::Lz4` is used by default for all queries except for `WATCH`.
 * `tls` (enabled by default) — supports urls with the `HTTPS` schema.
+* `rustls` - enables `rustls` TLS backend. You can use it to avoid OpenSSL dependency. As `tls` is enabled by default, you should disable the `default-features` to use `rustls`. Like this: `clickhouse = { version = "x.y.z", default-features = false, features = ["lz4", "quanta", "rustls"] }`
 * `quanta` (enabled by default) - uses the [quanta](https://docs.rs/quanta) crate to speed the inserter up. Not used if `test-util` is enabled (thus, time can be managed by `tokio::time::advance()` in custom tests).
 * `test-util` — adds mocks. See [the example](https://github.com/loyd/clickhouse.rs/tree/master/examples/mock.rs). Use it only in `dev-dependencies`.
 * `watch` — enables `client.watch` functionality. See the corresponding section for details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ impl Default for Client {
             .with_native_roots()
             .https_or_http()
             .enable_http2()
-            .wrap_connector(connector);
+            .build();
 
         let client = hyper::Client::builder()
             .pool_idle_timeout(POOL_IDLE_TIMEOUT)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,13 @@ impl Default for Client {
             connector
         });
 
+        #[cfg(feature = "rustls")]
+        let connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_or_http()
+            .enable_http2()
+            .wrap_connector(connector);
+
         let client = hyper::Client::builder()
             .pool_idle_timeout(POOL_IDLE_TIMEOUT)
             .build(connector);


### PR DESCRIPTION
For certain environments, users have to avoid native-tls. Thus using rustls would be a good alternative.