### PR TITLE
fix(response): detect failed queries even when the response status is 200 (OK)

### DIFF
--- a/examples/mock.rs
+++ b/examples/mock.rs
@@ -54,4 +54,9 @@ async fn main() {
     make_insert(&client, &list).await.unwrap();
     let rows: Vec<SomeRow> = recording.collect().await;
     assert_eq!(rows, list);
+
+    // How to test unsuccessful INSERT.
+    mock.add(test::handlers::exception(209));
+    let reason = make_insert(&client, &list).await;
+    assert_eq!(format!("{reason:?}"), r#"Err(BadResponse("Code: 209"))"#);
 }

--- a/src/test/handlers.rs
+++ b/src/test/handlers.rs
@@ -37,6 +37,15 @@ pub fn failure(status: StatusCode) -> impl Handler {
         .expect("invalid builder")
 }
 
+#[track_caller]
+pub fn exception(code: u8) -> impl Handler {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("X-ClickHouse-Exception-Code", code.to_string())
+        .body(Bytes::new())
+        .map(Thunk)
+        .expect("invalid builder")
+}
 // === provide ===
 
 #[track_caller]


### PR DESCRIPTION
Closes #255 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
