### PR TITLE
docs(client): explained how Client::clone works and added 2 tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,12 @@ mod rowbinary;
 mod ticks;
 
 /// A client containing HTTP pool.
+///
+/// ### Cloning behavior
+/// Clones share the same HTTP transport but store their own configurations.
+/// Any `with_*` configuration method (e.g., [`Client::with_option`]) applies
+/// only to future clones, because [`Client::clone`] creates a deep copy
+/// of the [`Client`] configuration, except the transport.
 #[derive(Clone)]
 pub struct Client {
     http: Arc<dyn HttpClient>,
@@ -517,5 +523,19 @@ mod client_tests {
         assert!(!client.validation);
         let client = client.with_validation(true);
         assert!(client.validation);
+    }
+
+    #[test]
+    fn it_does_follow_previous_configuration() {
+        let client = Client::default().with_option("async_insert", "1");
+        assert_eq!(client.options, client.clone().options,);
+    }
+
+    #[test]
+    fn it_does_not_follow_future_configuration() {
+        let client = Client::default();
+        let client_clone = client.clone();
+        let client = client.with_option("async_insert", "1");
+        assert_ne!(client.options, client_clone.options,);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #248 

Requested in #248 description was added on how `Client::clone` works, as well as 2 tests to prove this. 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
