### PR TITLE
feat(types): data types wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,8 @@ clickhouse-types = { version = "0.1.0", path = "types" }
 
 thiserror = "2.0"
 serde = "1.0.106"
+serde_with = "3.15.0"
+serde_bytes = "0.11.19"
 bytes = "1.5.0"
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
 http-body-util = "0.1.2"
@@ -153,6 +155,7 @@ chrono = { version = "0.4", optional = true, features = ["serde"] }
 bstr = { version = "1.11.0", default-features = false }
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
+derive_more = { version = "2.0.1", default-features = false, features = ["display", "from", "into", "as_ref", "deref", "deref_mut"] }
 
 [dev-dependencies]
 clickhouse-derive = { version = "0.2.0", path = "derive" }
@@ -163,7 +166,7 @@ hyper = { version = "1.1", features = ["server"] }
 indexmap = { version = "2.10.0", features = ["serde"] }
 linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
 fxhash = { version = "0.2.1" }
-serde_bytes = "0.11.4"
+serde_bytes = "0.11.19"
 serde_json = "1"
 serde_repr = "0.1.7"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/benches/select_nyc_taxi_data.rs
+++ b/benches/select_nyc_taxi_data.rs
@@ -22,7 +22,7 @@ pub enum PaymentType {
 
 /// Uses just `visit_seq` since the order of the fields matches the database schema.
 #[derive(Row, Deserialize)]
-#[allow(dead_code)]
+#[allow(dead_code, deprecated)]
 struct TripSmallSeqAccess {
     trip_id: u32,
     #[serde(with = "clickhouse::serde::time::datetime")]
@@ -48,7 +48,7 @@ struct TripSmallSeqAccess {
 /// Uses `visit_map` to deserialize instead of `visit_seq`,
 /// since the fields definition is correct, but the order is wrong.
 #[derive(Row, Deserialize)]
-#[allow(dead_code)]
+#[allow(dead_code, deprecated)]
 struct TripSmallMapAccess {
     pickup_ntaname: String,
     dropoff_ntaname: String,

--- a/examples/data_types_derive_simple.rs
+++ b/examples/data_types_derive_simple.rs
@@ -94,6 +94,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+#[allow(deprecated)]
 #[derive(Clone, Debug, PartialEq)]
 #[derive(clickhouse::Row, serde::Serialize, serde::Deserialize)]
 pub struct Row {

--- a/examples/data_types_variant.rs
+++ b/examples/data_types_variant.rs
@@ -143,6 +143,7 @@ enum MyRowVariant {
     Array(Vec<u16>),
     Boolean(bool),
     // attributes should work in this case, too
+    #[allow(deprecated)]
     #[serde(with = "clickhouse::serde::time::date")]
     Date(time::Date),
     // NB: by default, fetched as raw bytes

--- a/examples/time_types_example.rs
+++ b/examples/time_types_example.rs
@@ -2,6 +2,7 @@ use chrono::Duration;
 use clickhouse::Client;
 use serde::{Deserialize, Serialize};
 
+#[allow(deprecated)]
 #[derive(Debug, Serialize, Deserialize, clickhouse::Row)]
 struct TimeExample {
     #[serde(with = "clickhouse::serde::time::time")]
@@ -23,6 +24,7 @@ struct TimeExample {
     time64_nanos: time::Duration,
 }
 
+#[allow(deprecated)]
 #[derive(Debug, Serialize, Deserialize, clickhouse::Row)]
 struct TimeExampleChrono {
     #[serde(with = "clickhouse::serde::chrono::time")]

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -1,0 +1,504 @@
+use serde::{
+    de::{Deserialize, Deserializer},
+    ser::{Serialize, Serializer},
+};
+
+/// Macro to generate wrapper types with custom serde implementations,
+/// and convenience traits: [`From`], [`AsRef`], [`AsMut`], etc.
+macro_rules! clickhouse_wrapper_impl {
+    (
+        $wrapper_name:ident,
+        $inner_type:ty,
+        serialize = |$ser_val:ident, $ser_serializer:ident| $ser_body:block,
+        deserialize = |$de_deserializer:ident| -> $de_result:ty $de_body:block
+    ) => {
+        #[derive(Debug, Clone, PartialEq)]
+        #[derive(AsRef, Deref, AsMut, DerefMut, From, Into)]
+        pub struct $wrapper_name(pub $inner_type);
+
+        impl Serialize for $wrapper_name {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                let $ser_val = &self.0;
+                let $ser_serializer = serializer;
+                $ser_body
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $wrapper_name {
+            fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let $de_deserializer = deserializer;
+                let inner: $de_result = $de_body;
+                Ok(Self(inner))
+            }
+        }
+    };
+}
+
+pub mod blob {
+    use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
+    use serde::{Deserialize, Serialize};
+
+    /// While being stored in ClickHouse as String or LowCardinality(String),
+    /// Blob is represented as raw bytes, without any UTF-8 validation.
+    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(AsRef, Deref, AsMut, DerefMut, From, Into)]
+    pub struct ChBlobString(#[serde(with = "serde_bytes")] pub Vec<u8>);
+}
+
+pub mod fixed_string {
+    use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
+    use serde::{Deserialize, Serialize};
+    use serde_with::serde_as;
+    use std::fmt::Debug;
+
+    /// FixedString is represented as raw bytes, no UTF-8 validation.
+    /// It can be used with any byte array size, e.g., [u8; 16], [u8; 32], etc.
+    /// The size must match the FixedString(N) definition in ClickHouse.
+    ///
+    /// NB: [`serde_as`] is the easiest way to serialize/deserialize fixed-size arrays,
+    /// as by default, serde supports derive up to length 32.
+    ///
+    /// See https://docs.rs/serde_with/3.14.1/serde_with/#large-and-const-generic-arrays
+    #[serde_as]
+    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Serialize, Deserialize)]
+    #[derive(AsRef, Deref, AsMut, DerefMut, From, Into)]
+    pub struct ChFixedString<const N: usize>(#[serde_as(as = "[_; N]")] pub [u8; N]);
+}
+
+pub mod ipv4 {
+    use super::*;
+    use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
+    use std::net::Ipv4Addr;
+
+    clickhouse_wrapper_impl!(
+        ChIpv4,
+        Ipv4Addr,
+        serialize = |ipv4, serializer| { u32::from(*ipv4).serialize(serializer) },
+        deserialize = |deserializer| -> Ipv4Addr {
+            let ip: u32 = Deserialize::deserialize(deserializer)?;
+            Ipv4Addr::from(ip)
+        }
+    );
+}
+
+// NB: this is not really required, as IPv6 can be deserialized without additional attributes,
+// but for consistency with IPv4 we provide the wrapper.
+pub mod ipv6 {
+    use super::*;
+    use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
+    use std::net::Ipv6Addr;
+
+    clickhouse_wrapper_impl!(
+        ChIpv6,
+        Ipv6Addr,
+        serialize = |ipv6, serializer| { ipv6.octets().serialize(serializer) },
+        deserialize = |deserializer| -> Ipv6Addr {
+            let octets: [u8; 16] = Deserialize::deserialize(deserializer)?;
+            Ipv6Addr::from(octets)
+        }
+    );
+}
+
+#[cfg(feature = "uuid")]
+pub mod uuid {
+    use super::*;
+    use ::uuid::Uuid;
+    use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
+    use serde::de::Error as DeError;
+
+    clickhouse_wrapper_impl!(
+        ChUuid,
+        Uuid,
+        serialize = |uuid, serializer| {
+            if serializer.is_human_readable() {
+                uuid.to_string().serialize(serializer)
+            } else {
+                let bytes = uuid.as_u64_pair();
+                bytes.serialize(serializer)
+            }
+        },
+        deserialize = |deserializer| -> Uuid {
+            if deserializer.is_human_readable() {
+                let uuid_str: &str = Deserialize::deserialize(deserializer)?;
+                Uuid::parse_str(uuid_str).map_err(D::Error::custom)?
+            } else {
+                let bytes: (u64, u64) = Deserialize::deserialize(deserializer)?;
+                Ok(Uuid::from_u64_pair(bytes.0, bytes.1))?
+            }
+        }
+    );
+}
+
+#[cfg(any(feature = "time", feature = "chrono"))]
+mod precision {
+
+    // ClickHouse DateTime64 and Time64 support precision from 0 to 9 inclusive.
+    // See https://clickhouse.com/docs/sql-reference/data-types/datetime64
+    pub trait ValidPrecision<const N: u8> {}
+
+    impl ValidPrecision<0> for () {}
+    impl ValidPrecision<3> for () {}
+    impl ValidPrecision<6> for () {}
+    impl ValidPrecision<9> for () {}
+}
+
+#[cfg(any(feature = "time", feature = "chrono"))]
+macro_rules! clickhouse_datetime64_wrapper_impl {
+    (
+        $wrapper_type:ident,
+        $type:ident,
+        serialize = |$ser_val:ident, $ser_serializer:ident| $ser_body:block,
+        deserialize = |$de_deserializer:ident| -> $de_result:ty $de_body:block
+    ) => {
+        #[derive(Debug, Clone, PartialEq)]
+        #[derive(AsRef, Deref, AsMut, DerefMut, From, Into)]
+        pub struct $wrapper_type<const PRECISION: u8>(pub $type)
+        where
+            (): ValidPrecision<PRECISION>;
+
+        impl<const PRECISION: u8> Serialize for $wrapper_type<PRECISION>
+        where
+            (): ValidPrecision<PRECISION>,
+        {
+            fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+                let $ser_val = &self.0;
+                let $ser_serializer = ser;
+                $ser_body
+            }
+        }
+
+        impl<'de, const PRECISION: u8> Deserialize<'de> for $wrapper_type<PRECISION>
+        where
+            (): ValidPrecision<PRECISION>,
+        {
+            fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+                let $de_deserializer = de;
+                let inner: $de_result = $de_body;
+                Ok(Self(inner))
+            }
+        }
+    };
+}
+
+// Time crate wrappers (only when time feature is enabled)
+#[cfg(feature = "time")]
+pub mod time {
+    use super::*;
+    use ::time::{Date, Duration, OffsetDateTime, error::ComponentRange};
+    use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
+    use precision::*;
+    use serde::de::Error as DeError;
+    use serde::ser::Error as SerError;
+    use std::convert::TryFrom;
+    clickhouse_wrapper_impl!(
+        ChDate,
+        Date,
+        serialize = |date, serializer| {
+            const ORIGIN: Result<Date, ComponentRange> = Date::from_ordinal_date(1970, 1);
+            let origin = ORIGIN.unwrap();
+            if *date < origin {
+                let msg = format!("{date} cannot be represented as Date");
+                return Err(S::Error::custom(msg));
+            }
+
+            let elapsed = *date - origin;
+            let days = elapsed.whole_days();
+
+            u16::try_from(days)
+                .map_err(|_| S::Error::custom(format!("{date} cannot be represented as Date")))?
+                .serialize(serializer)
+        },
+        deserialize = |deserializer| -> Date {
+            const ORIGIN: Result<Date, ComponentRange> = Date::from_ordinal_date(1970, 1);
+            let days: u16 = Deserialize::deserialize(deserializer)?;
+            ORIGIN.unwrap() + Duration::days(i64::from(days))
+        }
+    );
+
+    clickhouse_wrapper_impl!(
+        ChDate32,
+        Date,
+        serialize = |date, serializer| {
+            const ORIGIN: Result<Date, ComponentRange> = Date::from_ordinal_date(1970, 1);
+            const MIN: Result<Date, ComponentRange> = Date::from_ordinal_date(1900, 1);
+            const MAX: Result<Date, ComponentRange> = Date::from_ordinal_date(2299, 365);
+
+            if *date < MIN.unwrap() || *date > MAX.unwrap() {
+                let msg = format!("{date} cannot be represented as Date32");
+                return Err(S::Error::custom(msg));
+            }
+
+            let elapsed = *date - ORIGIN.unwrap();
+            let days = elapsed.whole_days();
+
+            i32::try_from(days)
+                .map_err(|_| S::Error::custom(format!("{date} cannot be represented as Date32")))?
+                .serialize(serializer)
+        },
+        deserialize = |deserializer| -> Date {
+            const ORIGIN: Result<Date, ComponentRange> = Date::from_ordinal_date(1970, 1);
+            let days: i32 = Deserialize::deserialize(deserializer)?;
+            ORIGIN.unwrap() + Duration::days(i64::from(days))
+        }
+    );
+
+    clickhouse_wrapper_impl!(
+        ChDateTime,
+        OffsetDateTime,
+        serialize = |dt, serializer| {
+            let ts = dt.unix_timestamp();
+            u32::try_from(ts)
+                .map_err(|_| S::Error::custom(format!("{dt} cannot be represented as DateTime")))?
+                .serialize(serializer)
+        },
+        deserialize = |deserializer| -> OffsetDateTime {
+            let ts: u32 = Deserialize::deserialize(deserializer)?;
+            OffsetDateTime::from_unix_timestamp(i64::from(ts)).map_err(D::Error::custom)?
+        }
+    );
+
+    // DateTime64 variants
+    clickhouse_datetime64_wrapper_impl!(
+        ChDateTime64,
+        OffsetDateTime,
+        serialize = |value, serializer| {
+            let ts = if PRECISION == 0 {
+                value.unix_timestamp()
+            } else {
+                let divisor = match PRECISION {
+                    3 => 1_000_000,
+                    6 => 1_000,
+                    9 => 1,
+                    _ => unreachable!(), // Prevented by ValidPrecision trait
+                };
+                let ts = value.unix_timestamp_nanos() / divisor;
+                i64::try_from(ts).map_err(|_| {
+                    S::Error::custom(format!(
+                        "{} cannot be represented as Int64 for DateTime64 with precision {}",
+                        value, PRECISION
+                    ))
+                })?
+            };
+            ts.serialize(serializer)
+        },
+        deserialize = |deserializer| -> OffsetDateTime {
+            let mul = match PRECISION {
+                0 => 1_000_000_000,
+                3 => 1_000_000,
+                6 => 1_000,
+                9 => 1,
+                _ => unreachable!(), // Prevented by ValidPrecision trait
+            };
+
+            let ts: i64 = Deserialize::deserialize(deserializer)?;
+            let ts = i128::from(ts) * mul; // cannot overflow: `mul` fits in `i64`
+            OffsetDateTime::from_unix_timestamp_nanos(ts).map_err(D::Error::custom)?
+        }
+    );
+
+    // Time and Time64 variants for Duration
+    clickhouse_wrapper_impl!(
+        ChTime,
+        Duration,
+        serialize = |duration, serializer| {
+            let total_seconds = duration.whole_seconds();
+            i32::try_from(total_seconds)
+                .map_err(|_| S::Error::custom(format!("{duration} cannot be represented as Time")))?
+                .serialize(serializer)
+        },
+        deserialize = |deserializer| -> Duration {
+            let seconds: i32 = Deserialize::deserialize(deserializer)?;
+            Duration::seconds(seconds.into())
+        }
+    );
+
+    clickhouse_datetime64_wrapper_impl!(
+        ChTime64,
+        Duration,
+        serialize = |value, serializer| {
+            let total_seconds = if PRECISION == 0 {
+                value.whole_seconds()
+            } else {
+                let ts = match PRECISION {
+                    3 => value.whole_milliseconds(),
+                    6 => value.whole_microseconds(),
+                    9 => value.whole_nanoseconds(),
+                    _ => unreachable!(), // Prevented by ValidPrecision trait
+                };
+                i64::try_from(ts).map_err(|_| {
+                    S::Error::custom(format!(
+                        "{} cannot be represented as Int64 for Time64 with precision {}",
+                        value, PRECISION
+                    ))
+                })?
+            };
+            total_seconds.serialize(serializer)
+        },
+        deserialize = |deserializer| -> Duration {
+            let seconds: i64 = Deserialize::deserialize(deserializer)?;
+            match PRECISION {
+                0 => Duration::seconds(seconds),
+                3 => Duration::milliseconds(seconds),
+                6 => Duration::microseconds(seconds),
+                9 => Duration::nanoseconds(seconds),
+                _ => unreachable!(), // Prevented by ValidPrecision trait
+            }
+        }
+    );
+}
+
+#[cfg(feature = "chrono")]
+pub mod chrono {
+    use super::*;
+    use ::chrono::{DateTime, Duration, NaiveDate, Utc};
+    use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into};
+    use serde::de::Error as DeError;
+    use serde::ser::Error as SerError;
+    use std::convert::TryFrom;
+
+    // Date and Date32
+    clickhouse_wrapper_impl!(
+        ChChronoDate,
+        NaiveDate,
+        serialize = |date, serializer| {
+            const ORIGIN: Option<NaiveDate> = NaiveDate::from_yo_opt(1970, 1);
+            let origin = ORIGIN.unwrap();
+            if *date < origin {
+                let msg = format!("{date} cannot be represented as Date");
+                return Err(S::Error::custom(msg));
+            }
+
+            let elapsed = *date - origin;
+            let days = elapsed.num_days();
+
+            u16::try_from(days)
+                .map_err(|_| S::Error::custom(format!("{date} cannot be represented as Date")))?
+                .serialize(serializer)
+        },
+        deserialize = |deserializer| -> NaiveDate {
+            const ORIGIN: Option<NaiveDate> = NaiveDate::from_yo_opt(1970, 1);
+            let days: u16 = Deserialize::deserialize(deserializer)?;
+            ORIGIN.unwrap() + Duration::days(i64::from(days))
+        }
+    );
+
+    clickhouse_wrapper_impl!(
+        ChChronoDate32,
+        NaiveDate,
+        serialize = |date, serializer| {
+            const ORIGIN: Option<NaiveDate> = NaiveDate::from_yo_opt(1970, 1);
+            const MIN: Option<NaiveDate> = NaiveDate::from_yo_opt(1900, 1);
+            const MAX: Option<NaiveDate> = NaiveDate::from_yo_opt(2299, 365);
+
+            if *date < MIN.unwrap() || *date > MAX.unwrap() {
+                let msg = format!("{date} cannot be represented as Date32");
+                return Err(S::Error::custom(msg));
+            }
+
+            let elapsed = *date - ORIGIN.unwrap();
+            let days = elapsed.num_days();
+
+            i32::try_from(days)
+                .map_err(|_| S::Error::custom(format!("{date} cannot be represented as Date32")))?
+                .serialize(serializer)
+        },
+        deserialize = |deserializer| -> NaiveDate {
+            const ORIGIN: Option<NaiveDate> = NaiveDate::from_yo_opt(1970, 1);
+            let days: i32 = Deserialize::deserialize(deserializer)?;
+            ORIGIN.unwrap() + Duration::days(i64::from(days))
+        }
+    );
+
+    // DateTime
+    clickhouse_wrapper_impl!(
+        ChChronoDateTime,
+        DateTime<Utc>,
+        serialize = |dt, serializer| {
+            let ts = dt.timestamp();
+            u32::try_from(ts)
+                .map_err(|_| S::Error::custom(format!("{dt} cannot be represented as DateTime")))?
+                .serialize(serializer)
+        },
+        deserialize = |deserializer| -> DateTime<Utc> {
+            let ts: u32 = Deserialize::deserialize(deserializer)?;
+            DateTime::<Utc>::from_timestamp(i64::from(ts), 0).ok_or_else(|| {
+                D::Error::custom(format!("{ts} cannot be converted to DateTime<Utc>"))
+            })?
+        }
+    );
+
+    // DateTime64 variants
+    clickhouse_wrapper_impl!(
+        ChChronoDateTime64Secs,
+        DateTime<Utc>,
+        serialize = |dt, serializer| {
+            let ts = dt.timestamp();
+            ts.serialize(serializer)
+        },
+        deserialize = |deserializer| -> DateTime<Utc> {
+            let ts: i64 = Deserialize::deserialize(deserializer)?;
+            DateTime::<Utc>::from_timestamp(ts, 0)
+                .ok_or_else(|| D::Error::custom(format!("Can't create DateTime<Utc> from {ts}")))?
+        }
+    );
+
+    clickhouse_wrapper_impl!(
+        ChChronoDateTime64Millis,
+        DateTime<Utc>,
+        serialize = |dt, serializer| {
+            let ts = dt.timestamp_millis();
+            ts.serialize(serializer)
+        },
+        deserialize = |deserializer| -> DateTime<Utc> {
+            let ts: i64 = Deserialize::deserialize(deserializer)?;
+            DateTime::<Utc>::from_timestamp_millis(ts)
+                .ok_or_else(|| D::Error::custom(format!("Can't create DateTime<Utc> from {ts}")))?
+        }
+    );
+
+    clickhouse_wrapper_impl!(
+        ChChronoDateTime64Micros,
+        DateTime<Utc>,
+        serialize = |dt, serializer| {
+            let ts = dt.timestamp_micros();
+            ts.serialize(serializer)
+        },
+        deserialize = |deserializer| -> DateTime<Utc> {
+            let ts: i64 = Deserialize::deserialize(deserializer)?;
+            DateTime::<Utc>::from_timestamp_micros(ts)
+                .ok_or_else(|| D::Error::custom(format!("Can't create DateTime<Utc> from {ts}")))?
+        }
+    );
+
+    clickhouse_wrapper_impl!(
+        ChChronoDateTime64Nanos,
+        DateTime<Utc>,
+        serialize = |dt, serializer| {
+            let ts = dt.timestamp_nanos_opt().ok_or_else(|| {
+                S::Error::custom(format!("{dt} cannot be represented as DateTime64"))
+            })?;
+            ts.serialize(serializer)
+        },
+        deserialize = |deserializer| -> DateTime<Utc> {
+            let ts: i64 = Deserialize::deserialize(deserializer)?;
+            DateTime::<Utc>::from_timestamp_nanos(ts)
+        }
+    );
+
+    // Time and Time64 for Duration
+    clickhouse_wrapper_impl!(
+        ChChronoTime,
+        Duration,
+        serialize = |time, serializer| {
+            i32::try_from(time.num_seconds())
+                .map_err(|_| S::Error::custom(format!("{time} cannot be represented as Time")))?
+                .serialize(serializer)
+        },
+        deserialize = |deserializer| -> Duration {
+            let seconds: i32 = Deserialize::deserialize(deserializer)?;
+            Duration::seconds(seconds as i64)
+        }
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,16 @@ use crate::_priv::row_insert_metadata_query;
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 use tokio::sync::RwLock;
 
+pub mod data_types;
 pub mod error;
 pub mod insert;
 #[cfg(feature = "inserter")]
 pub mod inserter;
 pub mod query;
+#[deprecated(
+    since = "0.14.1",
+    note = "please use wrappers from the `clickhouse::data_types` module instead"
+)]
 pub mod serde;
 pub mod sql;
 #[cfg(feature = "test-util")]

--- a/src/rowbinary/tests.rs
+++ b/src/rowbinary/tests.rs
@@ -239,6 +239,7 @@ fn it_serializes_option_time32_some() {
 }
 
 #[cfg(feature = "chrono")]
+#[allow(deprecated)]
 #[test]
 fn it_serializes_time32_overflow_fails() {
     use crate::serde::chrono::time;
@@ -260,6 +261,7 @@ fn it_serializes_time32_overflow_fails() {
 }
 
 #[cfg(feature = "time")]
+#[allow(deprecated)]
 #[test]
 fn it_time_serializes_time64_millis_overflow_fails() {
     use crate::serde::time::time64::millis;
@@ -282,6 +284,7 @@ fn it_time_serializes_time64_millis_overflow_fails() {
 }
 
 #[cfg(feature = "time")]
+#[allow(deprecated)]
 #[test]
 fn it_time_serializes_time64_micros_overflow_fails() {
     use crate::serde::time::time64::micros;
@@ -303,6 +306,7 @@ fn it_time_serializes_time64_micros_overflow_fails() {
 }
 
 #[cfg(feature = "time")]
+#[allow(deprecated)]
 #[test]
 fn it_time_serializes_time64_nanos_overflow_fails() {
     use crate::serde::time::time64::nanos;

--- a/tests/it/chrono.rs
+++ b/tests/it/chrono.rs
@@ -15,6 +15,7 @@ use clickhouse::Row;
 async fn datetime() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::chrono::datetime")]
@@ -125,6 +126,7 @@ async fn datetime() {
 async fn date() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::chrono::date")]
@@ -178,6 +180,7 @@ async fn date() {
 async fn date32() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::chrono::date32")]
@@ -277,6 +280,7 @@ async fn time_round_trip() {
         .await
         .unwrap();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
     struct TimeRow {
         #[serde(with = "clickhouse::serde::chrono::time")]
@@ -324,6 +328,7 @@ async fn time_negative_round_trip() {
         .await
         .unwrap();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
     struct TimeRow {
         #[serde(with = "clickhouse::serde::chrono::time")]
@@ -381,6 +386,7 @@ async fn time64_round_trip() {
         .await
         .unwrap();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::chrono::time64::secs")]
@@ -466,6 +472,7 @@ async fn time64_negative_round_trip() {
         .await
         .unwrap();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::chrono::time64::secs")]

--- a/tests/it/ip.rs
+++ b/tests/it/ip.rs
@@ -8,6 +8,7 @@ use clickhouse::Row;
 async fn smoke() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::ipv4")]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -252,6 +252,7 @@ mod time;
 mod user_agent;
 mod uuid;
 mod variant;
+mod wrappers;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum TestEnv {

--- a/tests/it/rbwnat_smoke.rs
+++ b/tests/it/rbwnat_smoke.rs
@@ -682,6 +682,7 @@ async fn date_and_time() {
     use time::OffsetDateTime;
     use time::format_description::well_known::Iso8601;
 
+    #[allow(deprecated)]
     #[derive(Clone, Debug, Row, Serialize, Deserialize, PartialEq)]
     struct Data {
         #[serde(with = "clickhouse::serde::time::date")]
@@ -741,6 +742,7 @@ async fn date_and_time() {
 #[tokio::test]
 #[cfg(feature = "uuid")]
 async fn uuid() {
+    #[allow(deprecated)]
     #[derive(Clone, Debug, Row, Serialize, Deserialize, PartialEq)]
     struct Data {
         id: u16,
@@ -785,6 +787,7 @@ async fn uuid() {
 
 #[tokio::test]
 async fn ipv4_ipv6() {
+    #[allow(deprecated)]
     #[derive(Clone, Debug, Row, Serialize, Deserialize, PartialEq)]
     struct Data {
         id: u16,

--- a/tests/it/rbwnat_validation.rs
+++ b/tests/it/rbwnat_validation.rs
@@ -265,6 +265,7 @@ async fn invalid_nullable_low_cardinality() {
 #[tokio::test]
 #[cfg(feature = "time")]
 async fn invalid_serde_with() {
+    #[allow(deprecated)]
     #[derive(Debug, Row, Serialize, Deserialize, PartialEq)]
     struct Data {
         #[serde(with = "clickhouse::serde::time::datetime64::millis")]
@@ -603,6 +604,7 @@ async fn issue_113() {
 #[tokio::test]
 #[cfg(feature = "time")]
 async fn issue_114() {
+    #[allow(deprecated)]
     #[derive(Row, Deserialize, Debug, PartialEq)]
     struct Data {
         #[serde(with = "clickhouse::serde::time::date")]
@@ -638,6 +640,7 @@ async fn issue_114() {
 #[tokio::test]
 #[cfg(feature = "time")]
 async fn issue_173() {
+    #[allow(deprecated)]
     #[derive(Debug, Serialize, Deserialize, Row)]
     struct Data {
         log_id: String,

--- a/tests/it/time.rs
+++ b/tests/it/time.rs
@@ -12,6 +12,7 @@ use clickhouse::Row;
 async fn datetime() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::time::datetime")]
@@ -117,6 +118,7 @@ async fn datetime() {
 async fn date() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::time::date")]
@@ -170,6 +172,7 @@ async fn date() {
 async fn date32() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::time::date32")]
@@ -239,6 +242,7 @@ fn generate_dates(years: Range<i32>, count: usize) -> Vec<Date> {
 async fn time_roundtrip() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::time::time")]
@@ -285,6 +289,7 @@ async fn time_roundtrip() {
 async fn time_negative_roundtrip() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::time::time")]
@@ -349,6 +354,7 @@ async fn time64_roundtrip() {
         .await
         .unwrap();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::time::time64::secs")]
@@ -408,6 +414,7 @@ async fn time64_negative_roundtrip() {
         .await
         .unwrap();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::time::time64::secs")]

--- a/tests/it/uuid.rs
+++ b/tests/it/uuid.rs
@@ -9,6 +9,7 @@ use clickhouse::Row;
 async fn smoke() {
     let client = prepare_database!();
 
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
     struct MyRow {
         #[serde(with = "clickhouse::serde::uuid")]
@@ -54,6 +55,7 @@ async fn smoke() {
 
 #[tokio::test]
 async fn human_readable_smoke() {
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
     struct OursRow {
         #[serde(with = "clickhouse::serde::uuid")]

--- a/tests/it/variant.rs
+++ b/tests/it/variant.rs
@@ -12,6 +12,7 @@ async fn variant_data_type() {
 
     // NB: Inner Variant types are _always_ sorted alphabetically,
     // and should be defined in _exactly_ the same order in the enum.
+    #[allow(deprecated)]
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
     enum MyRowVariant {
         Array(Vec<i16>),

--- a/tests/it/wrappers.rs
+++ b/tests/it/wrappers.rs
@@ -1,0 +1,182 @@
+#![cfg(all(feature = "chrono", feature = "time", feature = "uuid"))]
+
+use clickhouse::data_types::blob::ChBlobString;
+use clickhouse::data_types::chrono::{ChChronoDate, ChChronoDate32, ChChronoDateTime};
+use clickhouse::data_types::fixed_string::ChFixedString;
+use clickhouse::data_types::ipv4::ChIpv4;
+use clickhouse::data_types::ipv6::ChIpv6;
+use clickhouse::data_types::time::*;
+use clickhouse::data_types::uuid::ChUuid;
+use clickhouse::sql::Identifier;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use time::{Date, Month, OffsetDateTime, Time};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn smoke() {
+    #[derive(Clone, Debug, PartialEq)]
+    #[derive(clickhouse::Row, serde::Serialize, serde::Deserialize)]
+    struct Row {
+        // Avoiding reading/writing strings as UTF-8 for blobs stored in a string column
+        blob_str: ChBlobString,
+        // FixedString is represented as raw bytes (similarly to `blob_str`, no UTF-8)
+        fixed_str: ChFixedString<4>,
+
+        uuid: ChUuid,
+        ipv4: ChIpv4,
+        ipv6: ChIpv6,
+
+        // decimal32_9_4: Decimal32,
+        // decimal64_18_8: Decimal64,
+        // decimal128_38_12: Decimal128,
+        time_date: ChDate,
+        time_date32: ChDate32,
+        time_datetime: ChDateTime,
+        time_datetime64_0: ChDateTime64<0>,
+        time_datetime64_3: ChDateTime64<3>,
+        time_datetime64_6: ChDateTime64<6>,
+        time_datetime64_9: ChDateTime64<9>,
+        time_time: ChTime,
+        time_time64_0: ChTime64<0>,
+        time_time64_3: ChTime64<3>,
+        time_time64_6: ChTime64<6>,
+        time_time64_9: ChTime64<9>,
+
+        chrono_date: ChChronoDate,
+        chrono_date32: ChChronoDate32,
+        chrono_datetime: ChChronoDateTime,
+        // chrono_datetime64_0: ChChronoDateTime<0>,
+        // chrono_datetime64_3: ChChronoDateTime<3>,
+        // chrono_datetime64_6: ChChronoDateTime<6>,
+        // chrono_datetime64_9: ChChronoDateTime<9>,
+    }
+
+    let client = prepare_database!();
+    let table_name = "test_wrappers";
+
+    client
+        .query(
+            "
+            CREATE OR REPLACE TABLE ?
+            (
+                blob_str             String,
+                fixed_str            FixedString(4),
+
+                uuid                 UUID,
+                ipv4                 IPv4,
+                ipv6                 IPv6,
+
+                -- decimal32_9_4        Decimal32(4),
+                -- decimal64_18_8       Decimal64(8),
+                -- decimal128_38_12     Decimal128(12),
+
+                time_date            Date,
+                time_date32          Date32,
+                time_datetime        DateTime('UTC'),
+                time_datetime64_0    DateTime64(0, 'UTC'),
+                time_datetime64_3    DateTime64(3, 'UTC'),
+                time_datetime64_6    DateTime64(6, 'UTC'),
+                time_datetime64_9    DateTime64(9, 'UTC'),
+
+                time_time            Time,
+                time_time64_0        Time64(0),
+                time_time64_3        Time64(3),
+                time_time64_6        Time64(6),
+                time_time64_9        Time64(9),
+
+                chrono_date          Date,
+                chrono_date32        Date32,
+                chrono_datetime      DateTime('UTC'),
+                -- chrono_datetime64_0  DateTime64(0, 'UTC'),
+                -- chrono_datetime64_3  DateTime64(3, 'UTC'),
+                -- chrono_datetime64_6  DateTime64(6, 'UTC'),
+                -- chrono_datetime64_9  DateTime64(9, 'UTC'),
+
+                -- chrono_time          Time,
+                -- chrono_time64_0      Time64(0),
+                -- chrono_time64_3      Time64(3),
+                -- chrono_time64_6      Time64(6),
+                -- chrono_time64_9      Time64(9)
+            ) Engine=MergeTree ORDER BY ()
+        ",
+        )
+        .bind(Identifier(table_name))
+        .with_option("enable_time_time64_type", "1")
+        .execute()
+        .await
+        .unwrap();
+
+    let row = Row {
+        fixed_str: [1, 2, 3, 4].into(),
+        uuid: Uuid::new_v4().into(),
+        ipv4: Ipv4Addr::from(255).into(),
+        ipv6: Ipv6Addr::from(1111).into(),
+        blob_str: "foo".to_string().into_bytes().into(),
+        // Allowed values ranges:
+        // - Date   = [1970-01-01, 2149-06-06]
+        // - Date32 = [1900-01-01, 2299-12-31]
+        // See
+        // - https://clickhouse.com/docs/en/sql-reference/data-types/date
+        // - https://clickhouse.com/docs/en/sql-reference/data-types/date32
+        time_date: Date::from_calendar_date(2149, Month::June, 6)
+            .unwrap()
+            .into(),
+        time_date32: Date::from_calendar_date(2299, Month::December, 31)
+            .unwrap()
+            .into(),
+        time_datetime: OffsetDateTime::from_unix_timestamp(u32::MAX as i64)
+            .unwrap()
+            .into(),
+        time_datetime64_0: max_datetime64(0).into(),
+        time_datetime64_3: max_datetime64(999_000).into(),
+        time_datetime64_6: max_datetime64(999_999).into(),
+        time_datetime64_9: max_datetime64_nanos().into(),
+        time_time: time::Duration::seconds(i32::MAX as i64).into(),
+        time_time64_0: time::Duration::seconds(i64::MAX / 1_000_000_000).into(),
+        time_time64_3: time::Duration::milliseconds(i64::MAX / 1_000_000).into(),
+        time_time64_6: time::Duration::microseconds(i64::MAX / 1_000).into(),
+        time_time64_9: time::Duration::nanoseconds(i64::MAX).into(),
+
+        chrono_date: chrono::NaiveDate::from_ymd_opt(2149, 6, 6).unwrap().into(),
+        chrono_date32: chrono::NaiveDate::from_ymd_opt(2299, 12, 31)
+            .unwrap()
+            .into(),
+        chrono_datetime: chrono::DateTime::from_timestamp(u32::MAX.into(), 0)
+            .unwrap()
+            .into(),
+        // TODO ...
+    };
+
+    let mut insert = client.insert::<Row>(table_name).await.unwrap();
+    insert.write(&row).await.unwrap();
+    insert.end().await.unwrap();
+
+    let rows = client
+        .query("SELECT * FROM ?")
+        .bind(Identifier(table_name))
+        .fetch_all::<Row>()
+        .await
+        .unwrap();
+    assert_eq!(rows, vec![row]);
+}
+
+// The allowed range for DateTime64(8) and lower is
+// [1900-01-01 00:00:00, 2299-12-31 23:59:59.99999999] UTC
+// See https://clickhouse.com/docs/en/sql-reference/data-types/datetime64
+fn max_datetime64(microseconds: u32) -> OffsetDateTime {
+    // 2262-04-11 23:47:16
+    OffsetDateTime::new_utc(
+        Date::from_calendar_date(2299, Month::December, 31).unwrap(),
+        Time::from_hms_micro(23, 59, 59, microseconds).unwrap(),
+    )
+}
+
+// DateTime64(8)/DateTime(9) allowed range is
+// [1900-01-01 00:00:00, 2262-04-11 23:47:16] UTC
+// See https://clickhouse.com/docs/en/sql-reference/data-types/datetime64
+fn max_datetime64_nanos() -> OffsetDateTime {
+    OffsetDateTime::new_utc(
+        Date::from_calendar_date(2262, Month::April, 11).unwrap(),
+        Time::from_hms_nano(23, 47, 15, 999_999_999).unwrap(),
+    )
+}


### PR DESCRIPTION
## Summary

> [!WARNING]
> This PR is a draft and a subject of many follow-up changes.

* Closes #236
* Marks `clickhouse::serde` as deprecated 

Consider the following examples:

[Before](https://github.com/ClickHouse/clickhouse-rs/blob/471cf26a6959af7b207cfbe0b91af823933ebf9d/examples/data_types_derive_simple.rs#L98-L172):

```rs
#[derive(Clone, Debug, PartialEq)]
#[derive(clickhouse::Row, serde::Serialize, serde::Deserialize)]
pub struct Row {
    // Avoiding reading/writing strings as UTF-8 for blobs stored in a string column
    #[serde(with = "serde_bytes")]
    pub blob_str: Vec<u8>,

    // FixedString is represented as raw bytes (similarly to `blob_str`, no UTF-8)
    pub fixed_str: [u8; 16],

    #[serde(with = "clickhouse::serde::uuid")]
    pub uuid: uuid::Uuid,

    #[serde(with = "clickhouse::serde::ipv4")]
    pub ipv4: std::net::Ipv4Addr,
    pub ipv6: std::net::Ipv6Addr,

    #[serde(with = "clickhouse::serde::time::date")]
    pub time_date: Date,
    #[serde(with = "clickhouse::serde::time::date32")]
    pub time_date32: Date,
    #[serde(with = "clickhouse::serde::time::datetime")]
    pub time_datetime: OffsetDateTime,
    #[serde(with = "clickhouse::serde::time::datetime64::secs")]
    pub time_datetime64_0: OffsetDateTime,
    #[serde(with = "clickhouse::serde::time::datetime64::millis")]
    pub time_datetime64_3: OffsetDateTime,
    #[serde(with = "clickhouse::serde::time::datetime64::micros")]
    pub time_datetime64_6: OffsetDateTime,
    #[serde(with = "clickhouse::serde::time::datetime64::nanos")]
    pub time_datetime64_9: OffsetDateTime,

    #[serde(with = "clickhouse::serde::chrono::date")]
    pub chrono_date: NaiveDate,
    #[serde(with = "clickhouse::serde::chrono::date32")]
    pub chrono_date32: NaiveDate,
    #[serde(with = "clickhouse::serde::chrono::datetime")]
    pub chrono_datetime: DateTime<Utc>,
}
```

After this PR:

```rs
#[derive(Clone, Debug, PartialEq)]
#[derive(Row, Serialize, Deserialize)]
struct Row {
    // Avoiding reading/writing strings as UTF-8 for blobs stored in a string column
    blob_str: ChBlobString,
    // FixedString is represented as raw bytes (similarly to `blob_str`, no UTF-8)
    fixed_str: ChFixedString<4>,

    uuid: ChUuid,
    ipv4: ChIpv4,
    ipv6: ChIpv6,

    time_date: ChDate,
    time_date32: ChDate32,
    time_datetime: ChDateTime,
    time_datetime64_0: ChDateTime64<0>,
    time_datetime64_3: ChDateTime64<3>,
    time_datetime64_6: ChDateTime64<6>,
    time_datetime64_9: ChDateTime64<9>,
    time_time: ChTime,
    time_time64_0: ChTime64<0>,
    time_time64_3: ChTime64<3>,
    time_time64_6: ChTime64<6>,
    time_time64_9: ChTime64<9>,

    chrono_date: ChChronoDate,
    chrono_date32: ChChronoDate32,
    chrono_datetime: ChChronoDateTime,
}
```

Adds a few new dependencies (will be revised before merging):

- [serde_with](https://crates.io/crates/serde_with) for FixedString support
- [serde_bytes](https://crates.io/crates/serde_bytes) for non-UTF-8 (blob) String support
- [derive_more](https://crates.io/crates/derive_more) to reduce boilerplate on deriving the standard traits

TODO:

- [x] `time` crate - Date, Date32, DateTime, DateTime64, Time, Time64
- [x] UUID
- [x] IPv4, IPv6
- [x] FixedString(N)
- [x] String (non-UTF8, i.e., BLOB)
- [x] `chrono` crate - Date, Date32, DateTime
- [ ] `chrono` crate - DateTime64, Time, Time64
- [ ] Decimal32/64/128 - via [fixnum](https://docs.rs/fixnum/latest/fixnum/) as [in the examples](https://github.com/ClickHouse/clickhouse-rs/blob/471cf26a6959af7b207cfbe0b91af823933ebf9d/examples/data_types_derive_simple.rs#L132-L134)? (+ `decimal-fixnum` feature flag)
- [ ] (U)Int256 - perhaps can start with just a byte array, e.g., `[u8; 32]` + `int256` feature flag
- [ ] [Geo types](https://github.com/ClickHouse/clickhouse-rs/blob/54216d63d674545031e4bd421ab6e9b2f9a294c1/examples/data_types_derive_containers.rs#L55-L60) + `geo` feature flag
- [ ] Naming convention, module structure, default traits impl
- [ ] Tidy up the dependencies based on the features enabled
