### PR TITLE
feat: add tracing spans for queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,8 @@ clickhouse-macros = { version = "0.3.0", path = "macros" }
 clickhouse-types = { version = "0.1.0", path = "types" }
 
 thiserror = "2.0"
-serde = "1.0.106"
+serde = { version = "1.0.106", features = ["derive"] }
+serde_json = "1"
 bytes = "1.5.0"
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
 http-body-util = "0.1.2"
@@ -153,18 +154,17 @@ chrono = { version = "0.4", optional = true, features = ["serde"] }
 bstr = { version = "1.11.0", default-features = false }
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
+tracing = "0.1"
 
 [dev-dependencies]
 clickhouse-macros = { version = "0.3.0", path = "macros" }
 criterion = "0.6"
-serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["full", "test-util"] }
 hyper = { version = "1.1", features = ["server"] }
 indexmap = { version = "2.10.0", features = ["serde"] }
 linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
 fxhash = { version = "0.2.1" }
 serde_bytes = "0.11.4"
-serde_json = "1"
 serde_repr = "0.1.7"
 uuid = { version = "1", features = ["v4", "serde"] }
 time = { version = "0.3.17", features = ["macros", "rand", "parsing"] }

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -354,6 +354,21 @@ impl<T> Insert<T> {
         debug_assert!(matches!(self.state, InsertState::NotStarted { .. }));
         let (client, sql) = self.state.client_with_sql().unwrap(); // checked above
 
+        let span = tracing::info_span!(
+            "clickhouse.insert",
+            status = tracing::field::Empty,
+            otel.status_code = tracing::field::Empty,
+            otel.kind = "CLIENT",
+            db.system.name = "clickhouse",
+            db.query.text = sql,
+            db.response.returned_rows = tracing::field::Empty,
+            db.response.read_bytes = tracing::field::Empty,
+            db.response.read_rows = tracing::field::Empty,
+            db.response.written_bytes = tracing::field::Empty,
+            db.response.written_rows = tracing::field::Empty,
+        )
+        .entered();
+
         let mut url = Url::parse(&client.url).map_err(|err| Error::InvalidParams(err.into()))?;
         let mut pairs = url.query_pairs_mut();
         pairs.clear();
@@ -385,9 +400,13 @@ impl<T> Insert<T> {
             .map_err(|err| Error::InvalidParams(Box::new(err)))?;
 
         let future = client.http.request(request);
+        let span = span.exit();
         // TODO: introduce `Executor` to allow bookkeeping of spawned tasks.
-        let handle =
-            tokio::spawn(async move { Response::new(future, Compression::None).finish().await });
+        let handle = tokio::spawn(async move {
+            Response::new(future, Compression::None, span)
+                .finish()
+                .await
+        });
 
         match self.row_metadata {
             None => (), // RowBinary is used, no header is required.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod response;
 mod row;
 mod row_metadata;
 mod rowbinary;
+mod summary_header;
 #[cfg(feature = "inserter")]
 mod ticks;
 
@@ -383,6 +384,12 @@ impl Client {
     /// Starts a new SELECT/DDL query.
     pub fn query(&self, query: &str) -> query::Query {
         query::Query::new(self, query)
+    }
+
+    /// Starts a new SELECT/DDL query, with the `wait_end_of_query` setting enabled
+    /// to buffer the full query results on the server
+    pub fn query_buffered(&self, query: &str) -> query::Query {
+        query::Query::new_buffered(self, query)
     }
 
     /// Enables or disables [`Row`] data types validation against the database schema

--- a/src/summary_header.rs
+++ b/src/summary_header.rs
@@ -1,0 +1,36 @@
+use serde::de::Error;
+use serde::{Deserialize, Deserializer};
+
+#[derive(Debug, serde::Deserialize)]
+pub(crate) struct Summary {
+    #[serde(deserialize_with = "int_in_string")]
+    pub read_rows: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub read_bytes: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub written_rows: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub written_bytes: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub total_rows_to_read: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub result_rows: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub result_bytes: Option<usize>,
+    #[serde(deserialize_with = "int_in_string")]
+    pub elapsed_ns: Option<usize>,
+}
+
+fn int_in_string<'de, D>(deser: D) -> Result<Option<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if let Some(string) = Option::<&str>::deserialize(deser)? {
+        let value: usize = string
+            .parse()
+            .map_err(|_| D::Error::custom("invalid integer"))?;
+        Ok(Some(value))
+    } else {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
## Summary
This adds support for `tracing` spans in clickhouse-rs. We use them for opentelemetry, but they're just generally useful. We've been running this (well, a version of this against 0.13.3) for a while with good results.

I haven't written any tests  yet, but I wanted to get a first pass on whether this sounds like something upstream would be interested in accepting before I did so.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [ ] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
