### PR TITLE
chore(readme): no_run instead of ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ struct MyRow {
     name: String,
 }
 
-async fn example(client: clickhouse::Client) -> Result<(), Box<dyn std::error::Error>> {
+async fn example(client: clickhouse::Client) -> clickhouse::error::Result<()> {
     let mut insert = client.insert::<MyRow>("some").await?;
-    insert.write(&MyRow { no: 0, name: "foo".to_string() }).await?;
-    insert.write(&MyRow { no: 1, name: "bar".to_string() }).await?;
+    insert.write(&MyRow { no: 0, name: "foo".into() }).await?;
+    insert.write(&MyRow { no: 1, name: "bar".into() }).await?;
     insert.end().await?;
     Ok(())
 }
@@ -219,7 +219,7 @@ inserter.end().await?;
 </summary>
 
 ```rust,no_run
-async fn example(client: clickhouse::Client) -> Result<(), Box<dyn std::error::Error>> {
+async fn example(client: clickhouse::Client) -> clickhouse::error::Result<()> {
     client.query("DROP TABLE IF EXISTS some").execute().await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Replaces ```rust,ignore``` with ```rust,no_run``` in README.md
- Closes #296 

## Checklist
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
