### PR TITLE
docs: fix comment on clickhouse::serde::chrono::date

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -262,7 +262,7 @@ pub mod chrono {
         }
     }
 
-    /// Ser/de `time::Date` to/from `Date`.
+    /// Ser/de `serde::NaiveDate` to/from `Date`.
     pub mod date {
         use super::*;
         use ::chrono::{Duration, NaiveDate};
@@ -301,7 +301,7 @@ pub mod chrono {
         }
     }
 
-    /// Ser/de `time::Date` to/from `Date32`.
+    /// Ser/de `chrono::NaiveDate` to/from `Date32`.
     pub mod date32 {
         use ::chrono::{Duration, NaiveDate};
 


### PR DESCRIPTION
## Summary
I noticed that the docstring is wrong for `clickhouse::serde::chrono::date` and `clickhouse::serde::chrono::date32` (was copied from the `time` version without updating).

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
