### PR TITLE
feat: support byte-string params, implement `Primitive` for `bytes::Bytes{Mut}`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ clickhouse-types = { version = "0.1.1", path = "types" }
 
 thiserror = "2.0"
 serde = "1.0.106"
-bytes = "1.5.0"
+bytes = { version = "1.5.0", features = ["serde"] }
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
 http-body-util = "0.1.2"
 hyper = "1.4"

--- a/src/row.rs
+++ b/src/row.rs
@@ -204,7 +204,24 @@ macro_rules! impl_primitive_for {
 
 // TODO: char? &str? SocketAddr? Path? Duration? NonZero*?
 impl_primitive_for![
-    bool, String, u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64,
+    bool,
+    String,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    f32,
+    f64,
+    bytes::Bytes,
+    bytes::BytesMut,
 ];
 
 macro_rules! count_tokens {

--- a/src/sql/escape.rs
+++ b/src/sql/escape.rs
@@ -29,6 +29,10 @@ pub(crate) fn escape(src: &str, dst: &mut impl fmt::Write) -> fmt::Result {
     dst.write_str(rest)
 }
 
+pub(crate) fn escape_ascii(s: &[u8], dst: &mut impl fmt::Write) -> fmt::Result {
+    write!(dst, "{}", s.escape_ascii())
+}
+
 // See https://clickhouse.com/docs/en/sql-reference/syntax#string
 pub(crate) fn hex_bytes(s: &[u8], dst: &mut impl fmt::Write) -> fmt::Result {
     dst.write_char('X')?;

--- a/src/sql/ser.rs
+++ b/src/sql/ser.rs
@@ -358,7 +358,6 @@ impl<'a, W: Write> Serializer for ParamSerializer<'a, W> {
 
     unsupported!(
         serialize_map(Option<usize>) -> Result<Impossible>,
-        serialize_bytes(&[u8]),
         serialize_unit,
         serialize_unit_struct(&'static str),
     );
@@ -378,6 +377,11 @@ impl<'a, W: Write> Serializer for ParamSerializer<'a, W> {
         serialize_f64(f64),
         serialize_bool(bool),
     );
+
+    #[inline]
+    fn serialize_bytes(self, v: &[u8]) -> std::result::Result<Self::Ok, Self::Error> {
+        Ok(escape::escape_ascii(v, self.writer)?)
+    }
 
     #[inline]
     fn serialize_char(self, value: char) -> Result {


### PR DESCRIPTION
## Summary
* Support `Query::param()` with types that use `Serializer::serialize_bytes()`
* Implement `Primitive` for `bytes::Bytes` and `bytes::BytesMut`

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
