### PR TITLE
refactor: don't set `readonly` by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,7 +605,6 @@ mod settings {
     pub(crate) const DEFAULT_FORMAT: &str = "default_format";
     pub(crate) const COMPRESS: &str = "compress";
     pub(crate) const DECOMPRESS: &str = "decompress";
-    pub(crate) const READONLY: &str = "readonly";
     pub(crate) const ROLE: &str = "role";
     pub(crate) const QUERY: &str = "query";
 }

--- a/tests/it/query_readonly.rs
+++ b/tests/it/query_readonly.rs
@@ -40,22 +40,24 @@ async fn readonly_user() {
 async fn test_fetch(client: &Client) {
     let query = select_readonly_setting_query(client);
     let initial_readonly_row = run_fetch(query).await;
-    assert_eq!(
-        initial_readonly_row.value, "1",
-        "initial `fetch` readonly setting value should be 1"
-    );
 
-    let query = select_readonly_setting_query(client).with_option("readonly", "0");
-    let disabled_readonly_row = run_fetch(query).await;
+    // As of 0.14.2, we won't be implicitly setting `readonly` anymore.
     assert_eq!(
-        disabled_readonly_row.value, "0",
-        "`fetch` modified readonly setting value should be 0"
+        initial_readonly_row.value, "0",
+        "initial `fetch` readonly setting value should be 0"
     );
 
     let query = select_readonly_setting_query(client).with_option("readonly", "1");
+    let disabled_readonly_row = run_fetch(query).await;
+    assert_eq!(
+        disabled_readonly_row.value, "1",
+        "`fetch` modified readonly setting value should be 1"
+    );
+
+    let query = select_readonly_setting_query(client).with_option("readonly", "0");
     let same_readonly_row = run_fetch(query).await;
     assert_eq!(
-        same_readonly_row.value, "1",
+        same_readonly_row.value, "0",
         "`fetch` should allow setting the same readonly setting value"
     );
 }
@@ -63,22 +65,24 @@ async fn test_fetch(client: &Client) {
 async fn test_fetch_bytes(client: &Client) {
     let query = select_readonly_setting_query(client);
     let initial_readonly_value = run_fetch_bytes(query).await;
-    assert_eq!(
-        initial_readonly_value, b"1\n",
-        "initial `fetch_bytes` readonly setting value should be 1"
-    );
 
-    let query = select_readonly_setting_query(client).with_option("readonly", "0");
-    let disabled_readonly_value = run_fetch_bytes(query).await;
+    // As of 0.14.2, we won't be implicitly setting `readonly` anymore.
     assert_eq!(
-        disabled_readonly_value, b"0\n",
-        "`fetch_bytes` modified readonly setting value should be 0"
+        initial_readonly_value, b"0\n",
+        "initial `fetch_bytes` readonly setting value should be 0"
     );
 
     let query = select_readonly_setting_query(client).with_option("readonly", "1");
+    let disabled_readonly_value = run_fetch_bytes(query).await;
+    assert_eq!(
+        disabled_readonly_value, b"1\n",
+        "`fetch_bytes` modified readonly setting value should be 1"
+    );
+
+    let query = select_readonly_setting_query(client).with_option("readonly", "0");
     let same_readonly_value = run_fetch_bytes(query).await;
     assert_eq!(
-        same_readonly_value, b"1\n",
+        same_readonly_value, b"0\n",
         "`fetch_bytes` should allow setting the same readonly setting value"
     );
 }
@@ -86,22 +90,24 @@ async fn test_fetch_bytes(client: &Client) {
 async fn test_fetch_one(client: &Client) {
     let query = select_readonly_setting_query(client);
     let initial_readonly_value: String = run_fetch_one(query).await;
-    assert_eq!(
-        initial_readonly_value, "1",
-        "initial `fetch_one` readonly setting value should be 1"
-    );
 
-    let query = select_readonly_setting_query(client).with_option("readonly", "0");
-    let disabled_readonly_value: String = run_fetch_one(query).await;
+    // As of 0.14.2, we won't be implicitly setting `readonly` anymore.
     assert_eq!(
-        disabled_readonly_value, "0",
-        "`fetch_one` modified readonly setting value should be 0"
+        initial_readonly_value, "0",
+        "initial `fetch_one` readonly setting value should be 0"
     );
 
     let query = select_readonly_setting_query(client).with_option("readonly", "1");
+    let disabled_readonly_value: String = run_fetch_one(query).await;
+    assert_eq!(
+        disabled_readonly_value, "1",
+        "`fetch_one` modified readonly setting value should be 1"
+    );
+
+    let query = select_readonly_setting_query(client).with_option("readonly", "0");
     let same_readonly_value: String = run_fetch_one(query).await;
     assert_eq!(
-        same_readonly_value, "1",
+        same_readonly_value, "0",
         "`fetch_one` should allow setting the same readonly setting value"
     );
 }
@@ -109,25 +115,27 @@ async fn test_fetch_one(client: &Client) {
 async fn test_fetch_optional(client: &Client) {
     let query = select_readonly_setting_query(client);
     let initial_readonly_value: Option<String> = run_fetch_optional(query).await;
+
+    // As of 0.14.2, we won't be implicitly setting `readonly` anymore.
     assert_eq!(
         initial_readonly_value.as_deref(),
-        Some("1"),
-        "initial `fetch_optional` readonly setting value should be 1"
-    );
-
-    let query = select_readonly_setting_query(client).with_option("readonly", "0");
-    let disabled_readonly_value: Option<String> = run_fetch_optional(query).await;
-    assert_eq!(
-        disabled_readonly_value.as_deref(),
         Some("0"),
-        "`fetch_optional` modified readonly setting value should be 0"
+        "initial `fetch_optional` readonly setting value should be 0"
     );
 
     let query = select_readonly_setting_query(client).with_option("readonly", "1");
+    let disabled_readonly_value: Option<String> = run_fetch_optional(query).await;
+    assert_eq!(
+        disabled_readonly_value.as_deref(),
+        Some("1"),
+        "`fetch_optional` modified readonly setting value should be 1"
+    );
+
+    let query = select_readonly_setting_query(client).with_option("readonly", "0");
     let same_readonly_value: Option<String> = run_fetch_optional(query).await;
     assert_eq!(
         same_readonly_value.as_deref(),
-        Some("1"),
+        Some("0"),
         "`fetch_optional` should allow setting the same readonly setting value"
     );
 }
@@ -135,25 +143,27 @@ async fn test_fetch_optional(client: &Client) {
 async fn test_fetch_all(client: &Client) {
     let query = select_readonly_setting_query(client);
     let initial_readonly_value: Vec<String> = run_fetch_all(query).await;
+
+    // As of 0.14.2, we won't be implicitly setting `readonly` anymore.
     assert_eq!(
         initial_readonly_value,
-        vec!["1"],
-        "initial `fetch_all` readonly setting value should be 1"
-    );
-
-    let query = select_readonly_setting_query(client).with_option("readonly", "0");
-    let disabled_readonly_value: Vec<String> = run_fetch_all(query).await;
-    assert_eq!(
-        disabled_readonly_value,
         vec!["0"],
-        "`fetch_all` modified readonly setting value should be 0"
+        "initial `fetch_all` readonly setting value should be 0"
     );
 
     let query = select_readonly_setting_query(client).with_option("readonly", "1");
+    let disabled_readonly_value: Vec<String> = run_fetch_all(query).await;
+    assert_eq!(
+        disabled_readonly_value,
+        vec!["1"],
+        "`fetch_all` modified readonly setting value should be 1"
+    );
+
+    let query = select_readonly_setting_query(client).with_option("readonly", "0");
     let same_readonly_value: Vec<String> = run_fetch_all(query).await;
     assert_eq!(
         same_readonly_value,
-        vec!["1"],
+        vec!["0"],
         "`fetch_all` should allow setting the same readonly setting value"
     );
 }


### PR DESCRIPTION
## Summary
* Don't set `readonly` by default to avoid conflicts with existing user settings. 
    * It can still be set/overridden using `Client::with_option()` or `Query::with_option()`.

closes #343 
fixes #373
closes #361 (superceded PR)

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
    - [x] ~Examples~
    - [x] ~Integration test (waiting on bikeshedding)~
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [x] Questions:
    - [x] ~I chose the method name `with_read_only` to match the `ReadOnly` enum even though the option name is `readonly`.  If it was `with_readonly()` then for consistency the enum should be named `Readonly` but that doesn't look right. Does this make sense?~
    - [x] ~Is `with_read_only` / the `ReadOnly` enum overkill? I imagine most of the time the reason to set `readonly` is to override what we set by default, which I'm deleting anyway as it's causing a regression (#373). Otherwise it's always possible to set through `with_option`/`set_option`.~
    - [x] ~Does it make sense that `with_read_only(false)` unsets the option rather than sending `readonly="0"`? Practically speaking, there isn't really a use for sending `readonly="0"` because it's either redundant (the user/session already has read-write permissions) or not allowed (the user/session is already read-only).~
