### PR TITLE
Handle Variant column NULL values (0xFF discriminator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+* `Variant` columns containing NULL values no longer fail with a schema mismatch error. Use `Option<MyEnum>` to deserialize nullable Variant columns. ([#400])
+
+[#400]: https://github.com/ClickHouse/clickhouse-rs/pull/400
+
 ## [0.15.0] - 2026-04-03
 
 ### Added

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -2,7 +2,7 @@ use crate::Row;
 use crate::error::{Error, Result};
 use crate::row_metadata::RowMetadata;
 use crate::rowbinary::utils::{ensure_size, get_unsigned_leb128};
-use crate::rowbinary::validation::{DataTypeValidator, SchemaValidator, SerdeType};
+use crate::rowbinary::validation::{DataTypeValidator, NullEncoding, SchemaValidator, SerdeType};
 use crate::types::int256;
 use bytes::Buf;
 use core::mem::size_of;
@@ -248,6 +248,22 @@ where
     #[inline(always)]
     fn deserialize_option<V: Visitor<'data>>(self, visitor: V) -> Result<V::Value> {
         ensure_size(&mut self.input, 1)?;
+
+        if self.validator.null_encoding() == Some(NullEncoding::Discriminator) {
+            // variant-style null: 0xFF discriminator = NULL, no value bytes follow.
+            // any other byte is a valid discriminator that deserialize_enum must read,
+            // so we only consume the byte on NULL and leave it for the enum path.
+            if self.input[0] == 0xFF {
+                self.input.advance(1);
+                // advance the validator past this column
+                let _ = self.inner(SerdeType::Option)?;
+                return visitor.visit_none();
+            }
+            let deserializer = &mut self.inner(SerdeType::Option)?;
+            return visitor.visit_some(deserializer);
+        }
+
+        // standard Nullable encoding: leading byte 0 = not null, 1 = null
         let is_null = self.input.get_u8();
         let deserializer = &mut self.inner(SerdeType::Option)?;
         match is_null {

--- a/src/rowbinary/validation.rs
+++ b/src/rowbinary/validation.rs
@@ -216,14 +216,25 @@ impl<'caller, R: Row> SchemaValidator<R> for DataTypeValidator<'caller, R> {
         if self.current_column_idx >= self.metadata.columns.len() {
             return None;
         }
-        let data_type = self.metadata.columns[self.current_column_idx]
-            .data_type
-            .remove_low_cardinality();
-        match data_type {
-            DataTypeNode::Nullable(_) => Some(NullEncoding::Nullable),
-            DataTypeNode::Variant(_) => Some(NullEncoding::Discriminator),
-            _ => None,
-        }
+        null_encoding_for(&self.metadata.columns[self.current_column_idx].data_type)
+    }
+}
+
+/// Returns the wire-level null encoding of the given type, transparently
+/// stripping `LowCardinality(T)` and `SimpleAggregateFunction(_, T)` since
+/// those are encoded identically to the inner `T`.
+///
+/// This must stay aligned with the same wrapper stripping in `validate_impl`.
+/// If the two drift, `deserialize_option` and `validate(SerdeType::Option)`
+/// will disagree on the NULL marker length and the input stream goes out of sync.
+fn null_encoding_for(node: &DataTypeNode) -> Option<NullEncoding> {
+    let node = node
+        .remove_low_cardinality()
+        .remove_simple_aggregate_function();
+    match node {
+        DataTypeNode::Nullable(_) => Some(NullEncoding::Nullable),
+        DataTypeNode::Variant(_) => Some(NullEncoding::Discriminator),
+        _ => None,
     }
 }
 
@@ -465,6 +476,38 @@ impl<'caller, R: Row> SchemaValidator<R> for Option<InnerDataTypeValidator<'_, '
     #[cold]
     fn get_schema_index(&self, _struct_idx: usize) -> Result<usize> {
         unreachable!()
+    }
+
+    /// Reports the null encoding of the next nested column the validator is
+    /// about to descend into. Required so that `deserialize_option` picks the
+    /// correct null-reading strategy for nested cases such as
+    /// `Vec<Option<Variant>>` (over `Array(Variant(...))`) or
+    /// `(_, Option<Variant>)` (over `Tuple(_, Variant(...))`).
+    fn null_encoding(&self) -> Option<NullEncoding> {
+        let inner = self.as_ref()?;
+        let node: &DataTypeNode = match &inner.kind {
+            InnerDataTypeValidatorKind::Array(t) => t,
+            InnerDataTypeValidatorKind::RootArray(t) => t,
+            InnerDataTypeValidatorKind::Nullable(t) => t,
+            InnerDataTypeValidatorKind::Tuple(elements) => elements.first()?,
+            InnerDataTypeValidatorKind::RootTuple(cols, idx) => &cols.get(*idx)?.data_type,
+            InnerDataTypeValidatorKind::Map(kv, MapValidatorState::Key) => &kv[0],
+            InnerDataTypeValidatorKind::Map(kv, MapValidatorState::Value) => &kv[1],
+            InnerDataTypeValidatorKind::MapAsSequence(kv, state) => match state {
+                // tuple state is a passthrough: the next validate call only
+                // updates state without consuming any wire bytes
+                MapAsSequenceValidatorState::Tuple => return None,
+                MapAsSequenceValidatorState::Key => &kv[0],
+                MapAsSequenceValidatorState::Value => &kv[1],
+            },
+            InnerDataTypeValidatorKind::Variant(types, VariantValidationState::Identifier(v)) => {
+                types.get(*v as usize)?
+            }
+            // FixedString / Enum / JsonWithHint / Variant(Pending) cannot
+            // host an Option<T> at this position
+            _ => return None,
+        };
+        null_encoding_for(node)
     }
 
     fn check_tuple_fully_validated(&self) -> Result<()> {

--- a/src/rowbinary/validation.rs
+++ b/src/rowbinary/validation.rs
@@ -211,6 +211,20 @@ impl<'caller, R: Row> SchemaValidator<R> for DataTypeValidator<'caller, R> {
     fn check_tuple_fully_validated(&self) -> Result<()> {
         unreachable!()
     }
+
+    fn null_encoding(&self) -> Option<NullEncoding> {
+        if self.current_column_idx >= self.metadata.columns.len() {
+            return None;
+        }
+        let data_type = self.metadata.columns[self.current_column_idx]
+            .data_type
+            .remove_low_cardinality();
+        match data_type {
+            DataTypeNode::Nullable(_) => Some(NullEncoding::Nullable),
+            DataTypeNode::Variant(_) => Some(NullEncoding::Discriminator),
+            _ => None,
+        }
+    }
 }
 
 /// Having a ClickHouse `Map<K, V>` defined as a `HashMap<K, V>` in Rust, Serde will call:
@@ -408,17 +422,31 @@ impl<'caller, R: Row> SchemaValidator<R> for Option<InnerDataTypeValidator<'_, '
                 }
                 IdentifierType::Variant => {
                     if let Variant(possible_types, state) = &mut inner.kind {
-                        // ClickHouse guarantees max 255 variants, i.e. the same max value as u8
-                        if value.into_u8() < (possible_types.len() as u8) {
-                            *state = VariantValidationState::Identifier(value.into_u8());
+                        let id = value.into_u8();
+                        if id < (possible_types.len() as u8) {
+                            *state = VariantValidationState::Identifier(id);
                         } else {
                             let (full_name, full_data_type) =
                                 inner.root.get_current_column_name_and_type()?;
 
+                            // 0xFF is the NULL discriminator for Variant columns.
+                            // reaching here means the Rust field is not Option<T>,
+                            // so it cannot represent NULL.
+                            let detail = if id == 0xFF {
+                                "received NULL (0xFF discriminator), \
+                                 but the field is not Option<T>"
+                                    .to_string()
+                            } else {
+                                format!(
+                                    "Variant identifier {id} is out of bounds, \
+                                     max allowed index is {}",
+                                    possible_types.len() - 1
+                                )
+                            };
+
                             return Err(Error::SchemaMismatch(format!(
-                                "While processing column {full_name} defined as {full_data_type}: \
-                                 Variant identifier {value} is out of bounds, max allowed index is {}",
-                                possible_types.len() - 1
+                                "While processing column {full_name} \
+                                 defined as {full_data_type}: {detail}"
                             )));
                         }
                     }
@@ -568,16 +596,20 @@ fn validate_impl<'serde, 'caller, R: Row>(
         {
             Ok(None)
         }
-        SerdeType::Option => {
-            if let DataTypeNode::Nullable(inner_type) = data_type {
-                Ok(Some(InnerDataTypeValidator {
-                    root,
-                    kind: InnerDataTypeValidatorKind::Nullable(inner_type),
-                }))
-            } else {
-                root.err_on_schema_mismatch(data_type, serde_type, is_inner)
-            }
-        }
+        SerdeType::Option => match data_type {
+            DataTypeNode::Nullable(inner_type) => Ok(Some(InnerDataTypeValidator {
+                root,
+                kind: InnerDataTypeValidatorKind::Nullable(inner_type),
+            })),
+            // variant is implicitly nullable; 0xFF discriminator = NULL.
+            // reuse Nullable inner kind as a passthrough so the subsequent
+            // SerdeType::Variant call resolves against the Variant data type.
+            DataTypeNode::Variant(_) => Ok(Some(InnerDataTypeValidator {
+                root,
+                kind: InnerDataTypeValidatorKind::Nullable(data_type),
+            })),
+            _ => root.err_on_schema_mismatch(data_type, serde_type, is_inner),
+        },
         SerdeType::Seq(_) => match data_type {
             DataTypeNode::Array(inner_type) => Ok(Some(InnerDataTypeValidator {
                 root,

--- a/src/rowbinary/validation.rs
+++ b/src/rowbinary/validation.rs
@@ -6,6 +6,18 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::marker::PhantomData;
 
+/// How a ClickHouse column encodes NULL on the wire.
+/// Different column types use different encodings; the deserializer
+/// needs to know which strategy to use when reading `Option<T>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NullEncoding {
+    /// `Nullable(T)`: a leading byte where 0 = not null, 1 = null.
+    Nullable,
+    /// `Variant(T1, T2, ...)`: NULL is encoded as discriminator 0xFF,
+    /// with no separate null byte and no value bytes following.
+    Discriminator,
+}
+
 /// This trait is used to validate the schema of a [`crate::Row`] against the parsed RBWNAT schema.
 /// Note that [`SchemaValidator`] is also implemented for `()`,
 /// which is used to skip validation if the user disabled it.
@@ -33,6 +45,12 @@ pub(crate) trait SchemaValidator<R: Row>: Sized {
     // If the database schema contains a tuple with more elements than it is defined in the struct,
     // this method will emit an error indicating that the struct definition is incomplete.
     fn check_tuple_fully_validated(&self) -> Result<()>;
+    /// Returns the null encoding of the current column, if known.
+    /// Called by the deserializer before reading any bytes in `deserialize_option`
+    /// to determine which null-reading strategy to use.
+    fn null_encoding(&self) -> Option<NullEncoding> {
+        None
+    }
 }
 
 pub(crate) struct DataTypeValidator<'caller, R: Row> {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -275,6 +275,7 @@ mod time;
 mod user_agent;
 mod uuid;
 mod variant;
+mod variant_null;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum TestEnv {

--- a/tests/it/variant_null.rs
+++ b/tests/it/variant_null.rs
@@ -32,7 +32,7 @@ async fn variant_null_values() {
             ENGINE = MergeTree
             ORDER BY id",
         )
-        .with_option("allow_experimental_variant_type", "1")
+        .with_setting("allow_experimental_variant_type", "1")
         .execute()
         .await
         .unwrap();

--- a/tests/it/variant_null.rs
+++ b/tests/it/variant_null.rs
@@ -67,7 +67,8 @@ async fn variant_null_values() {
     );
 }
 
-// exact reproduction from the issue: single query, no table needed
+// verifies that a NULL Variant value can be read without a table,
+// using an inline cast expression (e.g. `NULL::Variant(String, UInt64)`).
 #[tokio::test]
 async fn variant_null_cast() {
     let client = prepare_database!();

--- a/tests/it/variant_null.rs
+++ b/tests/it/variant_null.rs
@@ -94,3 +94,140 @@ async fn variant_null_cast() {
 
     assert_eq!(result.v, None);
 }
+
+/// Regression test for nested Variant inside an Array.
+/// Before the inner-validator `null_encoding` impl, `Vec<Option<MyVariant>>`
+/// over `Array(Variant(...))` would consume a discriminator byte as a
+/// Nullable flag and corrupt the input stream.
+#[tokio::test]
+async fn variant_null_in_array() {
+    let client = prepare_database!();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    enum SimpleVariant {
+        String(String),
+        UInt64(u64),
+    }
+
+    #[derive(Debug, PartialEq, Row, Deserialize)]
+    struct MyRow {
+        id: u32,
+        vars: Vec<Option<SimpleVariant>>,
+    }
+
+    client
+        .query(
+            "
+            CREATE OR REPLACE TABLE test_var_null_array
+            (
+                `id` UInt32,
+                `vars` Array(Variant(String, UInt64))
+            )
+            ENGINE = MergeTree
+            ORDER BY id",
+        )
+        .with_setting("allow_experimental_variant_type", "1")
+        .execute()
+        .await
+        .unwrap();
+
+    // Mix NULL and non-NULL discriminators in the same array so the
+    // deserializer has to switch paths element-by-element.
+    client
+        .query(
+            "INSERT INTO test_var_null_array VALUES \
+             (1, ['hello', NULL, 42, NULL, 'world'])",
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    let rows = client
+        .query("SELECT ?fields FROM test_var_null_array ORDER BY id")
+        .fetch_all::<MyRow>()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![MyRow {
+            id: 1,
+            vars: vec![
+                Some(SimpleVariant::String("hello".to_string())),
+                None,
+                Some(SimpleVariant::UInt64(42)),
+                None,
+                Some(SimpleVariant::String("world".to_string())),
+            ],
+        }]
+    );
+}
+
+/// Regression test for nested Variant inside a Tuple.
+/// Exercises the `Tuple(elements)` branch of the inner validator's
+/// `null_encoding`.
+#[tokio::test]
+async fn variant_null_in_tuple() {
+    let client = prepare_database!();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    enum SimpleVariant {
+        String(String),
+        UInt64(u64),
+    }
+
+    #[derive(Debug, PartialEq, Row, Deserialize)]
+    struct MyRow {
+        id: u32,
+        pair: (u32, Option<SimpleVariant>),
+    }
+
+    client
+        .query(
+            "
+            CREATE OR REPLACE TABLE test_var_null_tuple
+            (
+                `id` UInt32,
+                `pair` Tuple(UInt32, Variant(String, UInt64))
+            )
+            ENGINE = MergeTree
+            ORDER BY id",
+        )
+        .with_setting("allow_experimental_variant_type", "1")
+        .execute()
+        .await
+        .unwrap();
+
+    client
+        .query(
+            "INSERT INTO test_var_null_tuple VALUES \
+             (1, (10, 'hello')), (2, (20, NULL)), (3, (30, 42))",
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    let rows = client
+        .query("SELECT ?fields FROM test_var_null_tuple ORDER BY id")
+        .fetch_all::<MyRow>()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![
+            MyRow {
+                id: 1,
+                pair: (10, Some(SimpleVariant::String("hello".to_string()))),
+            },
+            MyRow {
+                id: 2,
+                pair: (20, None),
+            },
+            MyRow {
+                id: 3,
+                pair: (30, Some(SimpleVariant::UInt64(42))),
+            },
+        ]
+    );
+}

--- a/tests/it/variant_null.rs
+++ b/tests/it/variant_null.rs
@@ -1,0 +1,74 @@
+// https://github.com/ClickHouse/clickhouse-rs/issues/392
+// Variant is implicitly nullable: 0xFF discriminator = NULL.
+
+use serde::{Deserialize, Serialize};
+
+use clickhouse::Row;
+
+#[tokio::test]
+async fn variant_null_values() {
+    let client = prepare_database!();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    enum SimpleVariant {
+        String(String),
+        UInt64(u64),
+    }
+
+    #[derive(Debug, PartialEq, Row, Serialize, Deserialize)]
+    struct MyRow {
+        id: u32,
+        var: Option<SimpleVariant>,
+    }
+
+    client
+        .query(
+            "
+            CREATE OR REPLACE TABLE test_var_null
+            (
+                `id` UInt32,
+                `var` Variant(String, UInt64)
+            )
+            ENGINE = MergeTree
+            ORDER BY id",
+        )
+        .with_option("allow_experimental_variant_type", "1")
+        .execute()
+        .await
+        .unwrap();
+
+    // insert via SQL so we get actual NULLs in the Variant column
+    client
+        .query("INSERT INTO test_var_null VALUES (1, 'hello'), (2, NULL), (3, 42), (4, NULL)")
+        .execute()
+        .await
+        .unwrap();
+
+    let rows = client
+        .query("SELECT ?fields FROM test_var_null ORDER BY id")
+        .fetch_all::<MyRow>()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![
+            MyRow {
+                id: 1,
+                var: Some(SimpleVariant::String("hello".to_string())),
+            },
+            MyRow {
+                id: 2,
+                var: None,
+            },
+            MyRow {
+                id: 3,
+                var: Some(SimpleVariant::UInt64(42)),
+            },
+            MyRow {
+                id: 4,
+                var: None,
+            },
+        ]
+    );
+}

--- a/tests/it/variant_null.rs
+++ b/tests/it/variant_null.rs
@@ -87,6 +87,7 @@ async fn variant_null_cast() {
 
     let result = client
         .query("SELECT NULL::Variant(String, UInt64) AS v")
+        .with_setting("allow_experimental_variant_type", "1")
         .fetch_one::<Wrapper>()
         .await
         .unwrap();

--- a/tests/it/variant_null.rs
+++ b/tests/it/variant_null.rs
@@ -66,3 +66,29 @@ async fn variant_null_values() {
         ]
     );
 }
+
+// exact reproduction from the issue: single query, no table needed
+#[tokio::test]
+async fn variant_null_cast() {
+    let client = prepare_database!();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    enum SimpleVariant {
+        String(String),
+        UInt64(u64),
+    }
+
+    #[derive(Debug, PartialEq, Row, Deserialize)]
+    struct Wrapper {
+        #[serde(rename = "v")]
+        v: Option<SimpleVariant>,
+    }
+
+    let result = client
+        .query("SELECT NULL::Variant(String, UInt64) AS v")
+        .fetch_one::<Wrapper>()
+        .await
+        .unwrap();
+
+    assert_eq!(result.v, None);
+}

--- a/tests/it/variant_null.rs
+++ b/tests/it/variant_null.rs
@@ -57,18 +57,12 @@ async fn variant_null_values() {
                 id: 1,
                 var: Some(SimpleVariant::String("hello".to_string())),
             },
-            MyRow {
-                id: 2,
-                var: None,
-            },
+            MyRow { id: 2, var: None },
             MyRow {
                 id: 3,
                 var: Some(SimpleVariant::UInt64(42)),
             },
-            MyRow {
-                id: 4,
-                var: None,
-            },
+            MyRow { id: 4, var: None },
         ]
     );
 }


### PR DESCRIPTION
This PR tries to fix https://github.com/ClickHouse/clickhouse-rs/issues/392 by adding support for NULL values in Variant columns by handling the 0xFF discriminator.

Variant is implicitly nullable — NULL is encoded as discriminator `0xFF`, unlike `Nullable(T)` which uses a separate leading byte. The client now distinguishes between these two null encodings via a generic `NullEncoding` enum on the `SchemaValidator trait`, allowing `Option<MyEnum>` to work with Variant columns.


## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
