### PR TITLE
feat: HTTP TableBatcher with auto-flush triggers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ default = ["lz4"]
 
 test-util = ["hyper/server"]
 inserter = ["dep:quanta"]
+batcher = ["inserter", "tokio/time"]
 uuid = ["dep:uuid"]
 time = ["dep:time"]
 lz4 = ["dep:lz4_flex", "dep:cityhash-rs"]

--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -1,0 +1,187 @@
+//! Per-table batch inserter with automatic flushing.
+//!
+//! [`TableBatcher<T>`] wraps [`Inserter<T>`][crate::inserter::Inserter] with
+//! a shared buffer and a background task that handles period-based flushes,
+//! so callers don't need to poll `time_left()`.
+//!
+//! API names follow the ClickHouse Go client's
+//! [`Batch`](https://pkg.go.dev/github.com/ClickHouse/clickhouse-go/v2/lib/driver#Batch)
+//! interface: [`append`][TableBatcher::append] / [`flush`][TableBatcher::flush] /
+//! [`send`][TableBatcher::send].
+//!
+//! A flush fires when **any** of these thresholds are crossed:
+//! - serialised bytes reach [`BatchConfig::max_bytes`]
+//! - row count reaches [`BatchConfig::max_rows`]
+//! - [`BatchConfig::max_period`] elapses (background task)
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tokio::time::Duration;
+
+use crate::{
+    Client,
+    error::Result,
+    inserter::{Inserter, Quantities},
+    row::{Row, RowWrite},
+};
+
+/// Flush thresholds for [`TableBatcher`].
+///
+/// Defaults align with ClickHouse's async-insert defaults:
+/// `async_insert_max_data_size` = 10 MiB, `max_rows` = 100 000 (upper end of
+/// the recommended per-insert batch size to avoid MergeTree part fragmentation).
+#[derive(Debug, Clone)]
+pub struct BatchConfig {
+    /// Flush when this many rows have been buffered. Default: `100_000`.
+    pub max_rows: u64,
+    /// Flush when serialised bytes reach this size. Default: `10 MiB`.
+    pub max_bytes: u64,
+    /// Flush after this period regardless of row/byte counts. Default: `5 s`.
+    ///
+    /// `None` disables period-based flushing — no background task is spawned.
+    pub max_period: Option<Duration>,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self {
+            max_rows: 100_000,
+            max_bytes: 10 * 1024 * 1024,
+            max_period: Some(Duration::from_secs(5)),
+        }
+    }
+}
+
+impl BatchConfig {
+    /// Override the row-count flush threshold.
+    pub fn with_max_rows(mut self, n: u64) -> Self {
+        self.max_rows = n;
+        self
+    }
+
+    /// Override the byte-size flush threshold.
+    pub fn with_max_bytes(mut self, n: u64) -> Self {
+        self.max_bytes = n;
+        self
+    }
+
+    /// Override the period-based flush interval.
+    pub fn with_max_period(mut self, d: Duration) -> Self {
+        self.max_period = Some(d);
+        self
+    }
+
+    /// Disable period-based flushing (no background task is spawned).
+    pub fn without_period(mut self) -> Self {
+        self.max_period = None;
+        self
+    }
+}
+
+// HyperI CTO moonlighting — dfe-loader needed this and no one else was going to write it.
+
+struct BatcherInner<T> {
+    inserter: Inserter<T>,
+}
+
+/// Thread-safe, auto-flushing batch inserter for a single ClickHouse table.
+///
+/// Wraps [`Inserter<T>`][crate::inserter::Inserter] behind an `Arc<Mutex>` for
+/// concurrent writes and spawns a background task to handle period-based flushes.
+///
+/// Unlike `Inserter<T>`, this type accepts `&self` on [`append`][Self::append]
+/// and [`flush`][Self::flush], so it can be shared across tasks via [`Arc`].
+///
+/// Concurrent appends are serialised through the internal mutex. On the hot path
+/// (limits not yet reached) the lock covers only RowBinary serialisation. A flush
+/// holds the lock across the network round-trip, but that happens at most once per batch.
+///
+/// For multi-table writes create one `TableBatcher` per table and share via `Arc`.
+pub struct TableBatcher<T> {
+    inner: Arc<Mutex<BatcherInner<T>>>,
+    flush_task: tokio::task::JoinHandle<()>,
+}
+
+impl<T> TableBatcher<T>
+where
+    T: Row + RowWrite + Send + 'static,
+    for<'a> <T as Row>::Value<'a>: Send,
+{
+    /// Create a new `TableBatcher` for `table` using `config` thresholds.
+    ///
+    /// If `config.max_period` is `Some`, a background tokio task is spawned
+    /// to handle periodic flushes.
+    pub fn new(client: &Client, table: &str, config: BatchConfig) -> Self {
+        let inserter = client
+            .inserter::<T>(table)
+            .with_max_rows(config.max_rows)
+            .with_max_bytes(config.max_bytes)
+            .with_period(config.max_period);
+
+        let inner = Arc::new(Mutex::new(BatcherInner { inserter }));
+        let inner_bg = Arc::clone(&inner);
+        let period = config.max_period;
+
+        let flush_task = tokio::spawn(async move {
+            let Some(p) = period else { return };
+
+            let mut interval = tokio::time::interval(p);
+            // Skip ticks that arrive while a flush is already in progress.
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            // First tick fires immediately at t=0; skip it to avoid flushing an empty buffer.
+            interval.tick().await;
+
+            loop {
+                interval.tick().await;
+                let mut guard = inner_bg.lock().await;
+                if let Err(_err) = guard.inserter.commit().await {
+                    // Errors surface on the next explicit append/flush/send call.
+                    // Background tasks can't propagate errors to callers.
+                }
+            }
+        });
+
+        Self { inner, flush_task }
+    }
+
+    /// Add `row` to the buffer. Flushes automatically if a threshold is crossed.
+    pub async fn append(&self, row: &<T as Row>::Value<'_>) -> Result<()> {
+        let mut guard = self.inner.lock().await;
+        guard.inserter.write(row).await?;
+        guard.inserter.commit().await?;
+        Ok(())
+    }
+
+    /// Force-flush all pending rows to ClickHouse immediately.
+    ///
+    /// Returns the [`Quantities`] sent. Useful when shutting down a subsystem
+    /// while other clones of this batcher are still alive.
+    pub async fn flush(&self) -> Result<Quantities> {
+        let mut guard = self.inner.lock().await;
+        guard.inserter.force_commit().await
+    }
+
+    /// Flush remaining rows and shut down the batcher.
+    ///
+    /// Aborts the background flush task, waits for it to exit (so its `Arc`
+    /// clone is dropped), then finalises the INSERT via
+    /// [`Inserter::end`][crate::inserter::Inserter::end].
+    ///
+    /// All other `Arc` holders over the same inner buffer must be dropped before
+    /// calling `send`. If any remain after the abort, a force-flush is done
+    /// instead of a clean `end`.
+    pub async fn send(self) -> Result<Quantities> {
+        self.flush_task.abort();
+        let _ = self.flush_task.await;
+
+        match Arc::try_unwrap(self.inner) {
+            Ok(mutex) => mutex.into_inner().inserter.end().await,
+            Err(arc) => {
+                // Another Arc clone still exists — force-commit what we can.
+                let mut guard = arc.lock().await;
+                guard.inserter.force_commit().await
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod insert;
 pub mod insert_formatted;
 #[cfg(feature = "inserter")]
 pub mod inserter;
+#[cfg(feature = "batcher")]
+pub mod batcher;
 pub mod query;
 pub mod serde;
 pub mod sql;

--- a/tests/it/batcher.rs
+++ b/tests/it/batcher.rs
@@ -1,0 +1,169 @@
+use serde::{Deserialize, Serialize};
+
+use clickhouse::batcher::{BatchConfig, TableBatcher};
+use clickhouse::{Client, Row};
+
+#[derive(Debug, PartialEq, Eq, Row, Serialize, Deserialize)]
+struct MyRow {
+    id: u32,
+    data: String,
+}
+
+async fn create_table(client: &Client) {
+    client
+        .query(
+            "CREATE TABLE test(id UInt32, data String) \
+             ENGINE = MergeTree ORDER BY id",
+        )
+        .execute()
+        .await
+        .unwrap();
+}
+
+async fn count_rows(client: &Client) -> u64 {
+    client
+        .query("SELECT count() FROM test")
+        .fetch_one::<u64>()
+        .await
+        .unwrap()
+}
+
+// ── Basic append + send ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn batcher_basic() {
+    let client = prepare_database!();
+    create_table(&client).await;
+
+    let batcher = TableBatcher::<MyRow>::new(
+        &client,
+        "test",
+        BatchConfig::default().without_period(),
+    );
+
+    for i in 0..100u32 {
+        batcher
+            .append(&MyRow { id: i, data: i.to_string() })
+            .await
+            .unwrap();
+    }
+
+    batcher.send().await.unwrap();
+
+    assert_eq!(count_rows(&client).await, 100);
+}
+
+// ── flush() mid-stream ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn batcher_explicit_flush() {
+    let client = prepare_database!();
+    create_table(&client).await;
+
+    let batcher = TableBatcher::<MyRow>::new(
+        &client,
+        "test",
+        BatchConfig::default().without_period(),
+    );
+
+    for i in 0..50u32 {
+        batcher
+            .append(&MyRow { id: i, data: i.to_string() })
+            .await
+            .unwrap();
+    }
+
+    let q = batcher.flush().await.unwrap();
+    assert_eq!(q.rows, 50);
+    assert_eq!(count_rows(&client).await, 50);
+
+    for i in 50..100u32 {
+        batcher
+            .append(&MyRow { id: i, data: i.to_string() })
+            .await
+            .unwrap();
+    }
+
+    batcher.send().await.unwrap();
+    assert_eq!(count_rows(&client).await, 100);
+}
+
+// ── max_rows threshold ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn batcher_max_rows_flush() {
+    let client = prepare_database!();
+    create_table(&client).await;
+
+    // Flush every 10 rows.
+    let batcher = TableBatcher::<MyRow>::new(
+        &client,
+        "test",
+        BatchConfig::default().with_max_rows(10).without_period(),
+    );
+
+    for i in 0..35u32 {
+        batcher
+            .append(&MyRow { id: i, data: i.to_string() })
+            .await
+            .unwrap();
+    }
+
+    // 3 automatic flushes of 10 rows = 30 committed; 5 still buffered.
+    // send() flushes the remaining 5.
+    batcher.send().await.unwrap();
+
+    assert_eq!(count_rows(&client).await, 35);
+}
+
+// ── period-based background flush ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn batcher_period_flush() {
+    let client = prepare_database!();
+    create_table(&client).await;
+
+    let batcher = TableBatcher::<MyRow>::new(
+        &client,
+        "test",
+        BatchConfig::default()
+            .with_max_rows(u64::MAX)
+            .with_max_bytes(u64::MAX)
+            .with_max_period(tokio::time::Duration::from_millis(200)),
+    );
+
+    for i in 0..20u32 {
+        batcher
+            .append(&MyRow { id: i, data: i.to_string() })
+            .await
+            .unwrap();
+    }
+
+    // Wait long enough for two background flush ticks.
+    tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;
+
+    // Data should already be in ClickHouse from the background task.
+    assert_eq!(count_rows(&client).await, 20);
+
+    batcher.send().await.unwrap();
+    assert_eq!(count_rows(&client).await, 20);
+}
+
+// ── empty send() is safe ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn batcher_empty_send() {
+    let client = prepare_database!();
+    create_table(&client).await;
+
+    let batcher = TableBatcher::<MyRow>::new(
+        &client,
+        "test",
+        BatchConfig::default().without_period(),
+    );
+
+    // No appends — send() must not panic or error.
+    batcher.send().await.unwrap();
+
+    assert_eq!(count_rows(&client).await, 0);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -257,6 +257,8 @@ mod insert;
 mod insert_formatted;
 #[cfg(feature = "inserter")]
 mod inserter;
+#[cfg(feature = "batcher")]
+mod batcher;
 mod int128;
 mod int256;
 mod ip;


### PR DESCRIPTION
**Independent of other PRs -- can merge in any order.**

TableBatcher<T> with three flush triggers: max rows, max bytes, max
period. Background tokio task for timer flush. Thread-safe via
Arc<tokio::sync::Mutex>.

API mirrors the Go client Batch interface -- append(), flush(), send().