### PR TITLE
fix: use correct format for `User-Agent` header

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -8,7 +8,7 @@ fn get_user_agent(products_info: &[ProductInfo]) -> String {
     // See https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
     let pkg_ver = option_env!("CARGO_PKG_VERSION").unwrap_or("unknown");
     let rust_ver = option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("unknown");
-    let default_agent = format!("clickhouse-rs/{pkg_ver} (lv:rust/{rust_ver}, os:{OS})");
+    let default_agent = format!("clickhouse-rs/{pkg_ver} (lv:rust/{rust_ver}; os:{OS})");
     if products_info.is_empty() {
         default_agent
     } else {

--- a/tests/it/user_agent.rs
+++ b/tests/it/user_agent.rs
@@ -10,7 +10,7 @@ const OS: &str = std::env::consts::OS;
 async fn default_user_agent() {
     let table_name = "chrs_default_user_agent";
     let client = prepare_database!();
-    let expected_user_agent = format!("clickhouse-rs/{PKG_VER} (lv:rust/{RUST_VER}, os:{OS})");
+    let expected_user_agent = format!("clickhouse-rs/{PKG_VER} (lv:rust/{RUST_VER}; os:{OS})");
     assert_queries_user_agents(&client, table_name, &expected_user_agent).await;
 }
 
@@ -19,7 +19,7 @@ async fn user_agent_with_single_product_info() {
     let table_name = "chrs_user_agent_with_single_product_info";
     let client = prepare_database!().with_product_info("my-app", "0.1.0");
     let expected_user_agent =
-        format!("my-app/0.1.0 clickhouse-rs/{PKG_VER} (lv:rust/{RUST_VER}, os:{OS})");
+        format!("my-app/0.1.0 clickhouse-rs/{PKG_VER} (lv:rust/{RUST_VER}; os:{OS})");
     assert_queries_user_agents(&client, table_name, &expected_user_agent).await;
 }
 
@@ -30,7 +30,7 @@ async fn user_agent_with_multiple_product_info() {
         .with_product_info("my-datasource", "2.5.0")
         .with_product_info("my-app", "0.1.0");
     let expected_user_agent = format!(
-        "my-app/0.1.0 my-datasource/2.5.0 clickhouse-rs/{PKG_VER} (lv:rust/{RUST_VER}, os:{OS})"
+        "my-app/0.1.0 my-datasource/2.5.0 clickhouse-rs/{PKG_VER} (lv:rust/{RUST_VER}; os:{OS})"
     );
     assert_queries_user_agents(&client, table_name, &expected_user_agent).await;
 }


### PR DESCRIPTION
## Summary
When looking at our internal usage dashboard, I noticed it didn't have any data for the OS key. 

[Looking at the JS implementation](https://github.com/ClickHouse/clickhouse-js/blob/ca43c797b402ff5911e2e3fb79ee2b1fd13eba92/packages/client-node/src/utils/user_agent.ts#L16), it turns out we were supposed to use a semicolon (`;`), not a comma. Whoops.

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
