### PR TITLE
ci: cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ env:
   RUST_BACKTRACE: 1
   # note: MSRV now tracked in `rust-toolchain.toml`
 
+permissions:
+  contents: read
+
 jobs:
   # Clippy ensures successful compilation as well,
   # so we do not need a separate build check


### PR DESCRIPTION
The `ci` workflow runs cargo tests against ClickHouse. No GitHub API writes from the workflow, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.