### PR TITLE
docs: add clickhouse-ext-arrow usage example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,10 +22,10 @@ If something is missing, or you found a mistake in one of these examples, please
 - [data_types_derive_containers.rs](data_types_derive_containers.rs) - deriving container-like (Array, Tuple, Map, Nested, Geo) ClickHouse data types in a struct.
 - [data_types_variant.rs](data_types_variant.rs) - working with the [Variant data type](https://clickhouse.com/docs/en/sql-reference/data-types/variant).
 - [data_types_new_json.rs](data_types_new_json.rs) - working with the [new JSON data type](https://clickhouse.com/docs/en/sql-reference/data-types/newjson) as a String.
-- [arrow.rs](arrow.rs) - reading and writing [Apache Arrow](https://arrow.apache.org/) `RecordBatch`es via the [`clickhouse-ext-arrow`](../ext-arrow) crate.
 
 ### Special cases
 
+- [arrow.rs](arrow.rs) - reading and writing [Apache Arrow](https://arrow.apache.org/) `RecordBatch`es via the [`clickhouse-ext-arrow`](../ext-arrow) crate.
 - [custom_http_client.rs](custom_http_client.rs) - using a custom Hyper client, tweaking its connection pool settings
 - [custom_http_headers.rs](custom_http_headers.rs) - setting additional HTTP headers to the client, or overriding the generated ones
 - [opentelemetry.rs](opentelemetry.rs) - configuring the integration with [`tracing`] and [the OpenTelemetry Rust SDK]

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ If something is missing, or you found a mistake in one of these examples, please
 - [data_types_derive_containers.rs](data_types_derive_containers.rs) - deriving container-like (Array, Tuple, Map, Nested, Geo) ClickHouse data types in a struct.
 - [data_types_variant.rs](data_types_variant.rs) - working with the [Variant data type](https://clickhouse.com/docs/en/sql-reference/data-types/variant).
 - [data_types_new_json.rs](data_types_new_json.rs) - working with the [new JSON data type](https://clickhouse.com/docs/en/sql-reference/data-types/newjson) as a String.
+- [arrow.rs](arrow.rs) - reading and writing [Apache Arrow](https://arrow.apache.org/) `RecordBatch`es via the [`clickhouse-ext-arrow`](../ext-arrow) crate.
 
 ### Special cases
 

--- a/examples/arrow.rs
+++ b/examples/arrow.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+use arrow::array::{Int32Array, RecordBatch, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+
+use clickhouse::{Client, error::Result};
+use clickhouse_ext_arrow::{ArrowClientExt, ArrowQueryExt};
+
+// This example demonstrates the `clickhouse-ext-arrow` extension traits:
+//
+//   - `ArrowClientExt::insert_arrow()` — write Arrow `RecordBatch`es to a table.
+//   - `ArrowQueryExt::fetch_arrow()`   — stream the result of a `SELECT` as Arrow.
+//
+// See also: tests/it/arrow.rs
+
+const TABLE_NAME: &str = "chrs_arrow_example";
+
+async fn ddl(client: &Client) -> Result<()> {
+    client
+        .query(&format!(
+            "CREATE OR REPLACE TABLE {TABLE_NAME}(bar Int32, baz String) \
+             ENGINE = MergeTree ORDER BY bar"
+        ))
+        .execute()
+        .await
+}
+
+// `insert_arrow()` writes one or more `RecordBatch`es to a target table.
+//
+// The Arrow field names are used as the target table's column list for the
+// generated `INSERT ... FORMAT ArrowStream` query.
+async fn insert(client: &Client) -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("bar", DataType::Int32, false),
+        Field::new("baz", DataType::Utf8, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["one", "two", "three"])),
+        ],
+    )
+    .unwrap();
+
+    let mut insert = client.insert_arrow(TABLE_NAME)?;
+    insert.write(&batch).await?;
+    // For a multi-batch insert, call `insert.write(&batch).await?` repeatedly,
+    // then `insert.end().await?` to flush and finish the request.
+    insert.end().await?;
+
+    Ok(())
+}
+
+// `fetch_arrow()` streams the response as a sequence of Arrow `RecordBatch`es.
+async fn select(client: &Client) -> Result<()> {
+    let mut cursor = client
+        .query(&format!("SELECT bar, baz FROM {TABLE_NAME} ORDER BY bar"))
+        .fetch_arrow()?;
+
+    while let Some(batch) = cursor.next().await? {
+        println!("batch with {} row(s):\n{batch:?}", batch.num_rows());
+    }
+
+    Ok(())
+}
+
+// Convenience helper: collect the whole response into a single `RecordBatch`.
+// Allocates a fresh batch to concatenate the streamed pieces; use `select()`
+// above when you want to process batches as they arrive instead.
+async fn select_merged(client: &Client) -> Result<()> {
+    let batch = client
+        .query(&format!("SELECT bar, baz FROM {TABLE_NAME} ORDER BY bar"))
+        .fetch_arrow()?
+        .collect_merged()
+        .await?;
+
+    println!("merged batch with {} row(s):\n{batch:?}", batch.num_rows());
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::default().with_url("http://localhost:8123");
+
+    ddl(&client).await?;
+    insert(&client).await?;
+    select(&client).await?;
+    select_merged(&client).await?;
+
+    Ok(())
+}

--- a/examples/arrow.rs
+++ b/examples/arrow.rs
@@ -8,18 +8,17 @@ use clickhouse_ext_arrow::{ArrowClientExt, ArrowQueryExt};
 
 // This example demonstrates the `clickhouse-ext-arrow` extension traits:
 //
-//   - `ArrowClientExt::insert_arrow()` — write Arrow `RecordBatch`es to a table.
-//   - `ArrowQueryExt::fetch_arrow()`   — stream the result of a `SELECT` as Arrow.
+//   - `ArrowClientExt::insert_arrow()`: write Arrow `RecordBatch`es to a table.
+//   - `ArrowQueryExt::fetch_arrow()`: stream the result of a `SELECT` as Arrow.
 //
 // See also: tests/it/arrow.rs
 
 async fn ddl(client: &Client) -> Result<()> {
     client
         .query(
-            "CREATE OR REPLACE TABLE {table:Identifier} (bar Int32, baz String) \
+            "CREATE OR REPLACE TABLE chrs_arrow_example (bar Int32, baz String) \
              ENGINE = MergeTree ORDER BY bar",
         )
-        .param("table", "chrs_arrow_example")
         .execute()
         .await
 }
@@ -65,8 +64,7 @@ async fn insert(client: &Client) -> Result<()> {
 // `fetch_arrow()` streams the response as a sequence of Arrow `RecordBatch`es.
 async fn select(client: &Client) -> Result<()> {
     let mut cursor = client
-        .query("SELECT bar, baz FROM {table:Identifier} ORDER BY bar")
-        .param("table", "chrs_arrow_example")
+        .query("SELECT bar, baz FROM chrs_arrow_example ORDER BY bar")
         .fetch_arrow()?;
 
     while let Some(batch) = cursor.next().await? {
@@ -81,8 +79,7 @@ async fn select(client: &Client) -> Result<()> {
 // above when you want to process batches as they arrive instead.
 async fn select_merged(client: &Client) -> Result<()> {
     let batch = client
-        .query("SELECT bar, baz FROM {table:Identifier} ORDER BY bar")
-        .param("table", "chrs_arrow_example")
+        .query("SELECT bar, baz FROM chrs_arrow_example ORDER BY bar")
         .fetch_arrow()?
         .collect_merged()
         .await?;

--- a/examples/arrow.rs
+++ b/examples/arrow.rs
@@ -13,19 +13,18 @@ use clickhouse_ext_arrow::{ArrowClientExt, ArrowQueryExt};
 //
 // See also: tests/it/arrow.rs
 
-const TABLE_NAME: &str = "chrs_arrow_example";
-
 async fn ddl(client: &Client) -> Result<()> {
     client
-        .query(&format!(
-            "CREATE OR REPLACE TABLE {TABLE_NAME}(bar Int32, baz String) \
-             ENGINE = MergeTree ORDER BY bar"
-        ))
+        .query(
+            "CREATE OR REPLACE TABLE {table:Identifier} (bar Int32, baz String) \
+             ENGINE = MergeTree ORDER BY bar",
+        )
+        .param("table", "chrs_arrow_example")
         .execute()
         .await
 }
 
-// `insert_arrow()` writes one or more `RecordBatch`es to a target table.
+// `insert_arrow()` writes Arrow `RecordBatch`es to a target table.
 //
 // The Arrow field names are used as the target table's column list for the
 // generated `INSERT ... FORMAT ArrowStream` query.
@@ -35,19 +34,29 @@ async fn insert(client: &Client) -> Result<()> {
         Field::new("baz", DataType::Utf8, false),
     ]));
 
-    let batch = RecordBatch::try_new(
-        schema,
-        vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
-            Arc::new(StringArray::from(vec!["one", "two", "three"])),
-        ],
-    )
-    .unwrap();
+    let batches = [
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["one", "two"])),
+            ],
+        )
+        .unwrap(),
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![3])),
+                Arc::new(StringArray::from(vec!["three"])),
+            ],
+        )
+        .unwrap(),
+    ];
 
-    let mut insert = client.insert_arrow(TABLE_NAME)?;
-    insert.write(&batch).await?;
-    // For a multi-batch insert, call `insert.write(&batch).await?` repeatedly,
-    // then `insert.end().await?` to flush and finish the request.
+    let mut insert = client.insert_arrow("chrs_arrow_example")?;
+    for batch in &batches {
+        insert.write(batch).await?;
+    }
     insert.end().await?;
 
     Ok(())
@@ -56,7 +65,8 @@ async fn insert(client: &Client) -> Result<()> {
 // `fetch_arrow()` streams the response as a sequence of Arrow `RecordBatch`es.
 async fn select(client: &Client) -> Result<()> {
     let mut cursor = client
-        .query(&format!("SELECT bar, baz FROM {TABLE_NAME} ORDER BY bar"))
+        .query("SELECT bar, baz FROM {table:Identifier} ORDER BY bar")
+        .param("table", "chrs_arrow_example")
         .fetch_arrow()?;
 
     while let Some(batch) = cursor.next().await? {
@@ -71,7 +81,8 @@ async fn select(client: &Client) -> Result<()> {
 // above when you want to process batches as they arrive instead.
 async fn select_merged(client: &Client) -> Result<()> {
     let batch = client
-        .query(&format!("SELECT bar, baz FROM {TABLE_NAME} ORDER BY bar"))
+        .query("SELECT bar, baz FROM {table:Identifier} ORDER BY bar")
+        .param("table", "chrs_arrow_example")
         .fetch_arrow()?
         .collect_merged()
         .await?;

--- a/ext-arrow/README.md
+++ b/ext-arrow/README.md
@@ -24,6 +24,15 @@ clickhouse-ext-arrow = "0.1.0"
 
 [caret-versions]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#version-requirement-syntax
 
+## Usage
+
+See [`examples/arrow.rs`](../examples/arrow.rs) in the parent crate for a runnable example that
+covers both `fetch_arrow()` (`SELECT`) and `insert_arrow()` (`INSERT`). Run it with:
+
+```sh
+cargo run --package clickhouse --example arrow
+```
+
 ## Why a Separate Crate?
 
 At the time of the creation of this crate, the `arrow` family of crates has an unconventionally fast release cadence, 


### PR DESCRIPTION
## Summary

Adds a runnable `examples/arrow.rs` showing how to use `clickhouse-ext-arrow` for both Arrow reads and writes. The example follows the existing `tests/it/arrow.rs` coverage, but keeps the flow small enough for users to copy: create a table, insert one `RecordBatch`, stream query results with `fetch_arrow()`, and collect a merged batch.

The PR also links the example from `examples/README.md` and adds a short usage pointer in `ext-arrow/README.md` with the exact `cargo run` command.

Closes #433.

## Verification

- `cargo fmt --check`
- `cargo check --package clickhouse --example arrow`
- `cargo clippy --package clickhouse --example arrow -- -D warnings`
- `git diff --check`
