### PR TITLE
Release `clickhouse 0.15.1` / `clickhouse-ext-arrow 0.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Introduced support for [Apache Arrow in Rust] via a new extension crate, [`clickhouse-ext-arrow`]. ([#423])
+* Introduced support for [Apache Arrow in Rust] via a new extension crate, [`clickhouse-ext-arrow`](ext-arrow/README.md). ([#423])
     * The CHANGELOG for this new crate is tracked in [ext-arrow/CHANGELOG.md](ext-arrow/CHANGELOG.md).
     * See [examples/arrow.rs](examples/arrow.rs) for usage.
 * Added `BytesCursor::poll_next()` ([#423])
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed `User-Agent` header generation to use correct format for server-side logging/metrics. ([#428])
 
 [Apache Arrow in Rust]: https://crates.io/crates/arrow
-[`clickhouse-ext-arrow`]: https://crates.io/crates/clickhouse-ext-arrow
 
 [#400]: https://github.com/ClickHouse/clickhouse-rs/pull/400
 [#423]: https://github.com/ClickHouse/clickhouse-rs/pull/423

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+## [0.15.1] - 2026-06-01
+
+### Added
+
+* Introduced support for [Apache Arrow in Rust] via a new extension crate, [`clickhouse-ext-arrow`]. ([#423])
+    * The CHANGELOG for this new crate is tracked in [ext-arrow/CHANGELOG.md](ext-arrow/CHANGELOG.md).
+    * Usage example 
+* Added `BytesCursor::poll_next()` ([#423])
+
 ### Fixed
 
-* `Variant` columns containing NULL values no longer fail with a schema mismatch error. Use `Option<MyEnum>` to deserialize nullable Variant columns. ([#400])
+* `Variant` columns containing NULL values no longer fail with a schema mismatch error. 
+  Use `Option<MyEnum>` to deserialize nullable Variant columns. ([#400])
+* Changed `User-Agent` header generation to use correct format for server-side logging/metrics. ([#428])
+
+[Apache Arrow in Rust]: https://crates.io/crates/arrow
+[`clickhouse-ext-arrow`]: https://crates.io/crates/clickhouse-ext-arrow
 
 [#400]: https://github.com/ClickHouse/clickhouse-rs/pull/400
+[#423]: https://github.com/ClickHouse/clickhouse-rs/pull/423
+[#428]: https://github.com/ClickHouse/clickhouse-rs/pull/428
 
 ## [0.15.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Introduced support for [Apache Arrow in Rust] via a new extension crate, [`clickhouse-ext-arrow`]. ([#423])
     * The CHANGELOG for this new crate is tracked in [ext-arrow/CHANGELOG.md](ext-arrow/CHANGELOG.md).
-    * Usage example 
+    * See [examples/arrow.rs](examples/arrow.rs) for usage.
 * Added `BytesCursor::poll_next()` ([#423])
 
 ### Fixed

--- a/ext-arrow/CHANGELOG.md
+++ b/ext-arrow/CHANGELOG.md
@@ -12,5 +12,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
-* Added `ArrowClientExt`, implemented for `clickhouse::Client` and providing `insert_arrow()`
+* Added `ArrowClientExt`, implemented for `clickhouse::Client` and providing `insert_arrow()` and `insert_arrow_with()`
 * Added `ArrowQueryExt`, implemented for `clickhouse::query::Query` and providing `fetch_arrow()`

--- a/ext-arrow/CHANGELOG.md
+++ b/ext-arrow/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+## [0.1.0] - 2026-06-01
+
+Initial release.
+
+* Added `ArrowClientExt`, implemented for `clickhouse::Client` and providing `insert_arrow()`
+* Added `ArrowQueryExt`, implemented for `clickhouse::query::Query` and providing `fetch_arrow()`

--- a/ext-arrow/Cargo.toml
+++ b/ext-arrow/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clickhouse-ext-arrow"
 version = "0.1.0"
-authors.workspace = true
+authors = ["ClickHouse Contributors"]
 repository.workspace = true
 homepage.workspace = true
 edition.workspace = true


### PR DESCRIPTION
Main release: https://github.com/ClickHouse/clickhouse-rs/blob/release/0.15.1/CHANGELOG.md
`clickhouse-ext-arrow` release: https://github.com/ClickHouse/clickhouse-rs/blob/release/0.15.1/ext-arrow/CHANGELOG.md

Question: should I create a separate tag for the `clickhouse-ext-arrow` release? It could be something like `clickhouse-ext-arrow/v0.1.0`.
