### PR TITLE
feat: implement native format reading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,8 @@ bstr = { version = "1.11.0", default-features = false }
 quanta = { version = "0.12", optional = true }
 polonius-the-crab = "0.5.0"
 
+hashbrown = "0.17.1"
+
 bnum = "0.13.0"
 
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }

--- a/src/cursors/mod.rs
+++ b/src/cursors/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) use self::raw::RawCursor;
-pub use self::{bytes::BytesCursor, row::RowCursor};
+pub use self::{bytes::BytesCursor, native::NativeCursor, row::RowCursor};
 
 mod bytes;
+mod native;
 mod raw;
 mod row;

--- a/src/cursors/native.rs
+++ b/src/cursors/native.rs
@@ -3,7 +3,6 @@ use crate::native::Block;
 use crate::native::reader::BlockReader;
 use crate::response::{Response, ResponseFuture};
 use futures_util::future::BoxFuture;
-use std::ops::ControlFlow;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 

--- a/src/cursors/native.rs
+++ b/src/cursors/native.rs
@@ -1,0 +1,76 @@
+use crate::error::Error;
+use crate::native::Block;
+use crate::native::reader::BlockReader;
+use crate::response::{Response, ResponseFuture};
+use futures_util::future::BoxFuture;
+use std::ops::ControlFlow;
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
+
+pub struct NativeCursor {
+    state: CursorState,
+    span: tracing::Span,
+}
+
+enum CursorState {
+    Loading(ResponseFuture),
+    Reading(BoxFuture<'static, Result<Option<(Block, BlockReader)>, Error>>),
+    Done,
+}
+
+impl NativeCursor {
+    pub(crate) fn new(response: Response, span: tracing::Span) -> Self {
+        NativeCursor {
+            state: CursorState::Loading(response.into_future()),
+            span,
+        }
+    }
+
+    pub async fn next(&mut self) -> Result<Option<Block>, Error> {
+        std::future::poll_fn(|cx| self.poll_next(cx)).await
+    }
+
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<Block>, Error>> {
+        let _span = self.span.enter();
+
+        loop {
+            match &mut self.state {
+                CursorState::Loading(fut) => {
+                    match ready!(Pin::new(fut).poll(cx)) {
+                        // TODO: expose summary
+                        Ok((chunks, _summary)) => {
+                            self.state = CursorState::Reading(Box::pin(read_block(
+                                BlockReader::new(chunks),
+                            )));
+                        }
+                        Err(e) => {
+                            self.state = CursorState::Done;
+                            return Poll::Ready(Err(e));
+                        }
+                    }
+                }
+                CursorState::Reading(fut) => {
+                    return match ready!(Pin::new(fut).poll(cx)) {
+                        Ok(Some((block, reader))) => {
+                            self.state = CursorState::Reading(Box::pin(read_block(reader)));
+                            Poll::Ready(Ok(Some(block)))
+                        }
+                        Ok(None) => {
+                            self.state = CursorState::Done;
+                            Poll::Ready(Ok(None))
+                        }
+                        Err(e) => {
+                            self.state = CursorState::Done;
+                            Poll::Ready(Err(e))
+                        }
+                    };
+                }
+                CursorState::Done => return Poll::Ready(Ok(None)),
+            }
+        }
+    }
+}
+
+async fn read_block(mut reader: BlockReader) -> Result<Option<(Block, BlockReader)>, Error> {
+    Ok(reader.read_block().await?.map(|block| (block, reader)))
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 //! Contains [`Error`] and corresponding [`Result`].
 
-use crate::native;
 use crate::native::BlockReadError;
 use serde::{de, ser};
 use std::{error::Error as StdError, fmt, io, result, str::Utf8Error};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 //! Contains [`Error`] and corresponding [`Result`].
 
+use crate::native;
+use crate::native::BlockReadError;
 use serde::{de, ser};
 use std::{error::Error as StdError, fmt, io, result, str::Utf8Error};
 
@@ -21,6 +23,8 @@ pub enum Error {
     Compression(#[source] BoxedError),
     #[error("decompression error: {0}")]
     Decompression(#[source] BoxedError),
+    #[error("data format error: {0}")]
+    DataFormat(#[source] BoxedError),
     #[error("no rows returned by a query that expected to return at least one row")]
     RowNotFound,
     #[error("sequences must have a known size ahead of time")]
@@ -112,6 +116,12 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<BlockReadError> for Error {
+    fn from(error: BlockReadError) -> Self {
+        Self::DataFormat(Box::new(error))
+    }
+}
+
 impl Error {
     /// https://opentelemetry.io/docs/specs/semconv/registry/attributes/error/#error-type
     #[cfg(feature = "opentelemetry")]
@@ -121,6 +131,7 @@ impl Error {
             Error::Network(_) => "Network",
             Error::Compression(_) => "Compression",
             Error::Decompression(_) => "Decompression",
+            Error::DataFormat(_) => "DataFormat",
             Error::RowNotFound => "RowNotFound",
             Error::SequenceMustHaveLength => "SequenceMustHaveLength",
             Error::DeserializeAnyNotSupported => "DeserializeAnyNotSupported",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ pub mod insert;
 pub mod insert_formatted;
 #[cfg(feature = "inserter")]
 pub mod inserter;
+pub mod native;
+
 pub mod query;
 pub mod serde;
 pub mod sql;

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -22,6 +22,35 @@ pub struct ArrayData<'a> {
     pub(super) indices: Range<usize>,
 }
 
+pub struct TupleIter<'a> {
+    pub(super) types: slice::Iter<'a, DataTypeNode>,
+    pub(super) layouts: slice::Iter<'a, Layout>,
+    pub(super) index: usize,
+}
+
+enum IterKind<'a> {
+    Fixed(slice::ChunksExact<'a, u8>),
+    Variable {
+        next_start: usize,
+        end_indices: slice::Iter<'a, usize>,
+        data: &'a [u8],
+    },
+    Array {
+        next_start: usize,
+        end_indices: slice::Iter<'a, usize>,
+        elem_layout: &'a Layout,
+    },
+    Tuple {
+        layouts: &'a [Layout],
+        elem_indices: Range<usize>,
+    },
+    Map {
+        next_start: usize,
+        end_indices: slice::Iter<'a, usize>,
+        key_val_layouts: &'a [Layout; 2],
+    },
+}
+
 impl<'a> ArrayData<'a> {
     pub fn into_reader<T>(self) -> Result<ArrayReader<'a, T>, Error>
     where
@@ -73,6 +102,18 @@ impl<'a> ArrayData<'a> {
                     next_start: 0,
                     end_indices: end_indices.iter(),
                     elem_layout,
+                },
+                LayoutKind::Tuple { ref layouts } => IterKind::Tuple {
+                    layouts,
+                    elem_indices: self.indices.clone(),
+                },
+                LayoutKind::Map {
+                    ref key_val_layouts,
+                    ref end_indices,
+                } => IterKind::Map {
+                    next_start: 0,
+                    key_val_layouts,
+                    end_indices: end_indices.iter(),
                 },
                 LayoutKind::LowCardinality(_) => todo!("implement LowCardinality"),
             },
@@ -169,20 +210,77 @@ where
                     .map_err(Error::Other),
                 )
             }
+            IterKind::Tuple {
+                layouts,
+                elem_indices,
+            } => {
+                let DataTypeNode::Tuple(types) = self.elem_type else {
+                    unreachable!("BUG: expected tuple type, got {:?}", self.elem_type)
+                };
+
+                let index = elem_indices.next()?;
+
+                // Need to make sure we advance the main iterator first
+                check_null!();
+
+                Some(
+                    T::decode_tuple(TupleIter {
+                        layouts: layouts.iter(),
+                        types: types.iter(),
+                        index,
+                    })
+                    .map_err(Error::Other),
+                )
+            }
+            IterKind::Map {
+                next_start,
+                end_indices,
+                key_val_layouts: [key_layout, val_layout],
+            } => {
+                let DataTypeNode::Map([key_ty, val_ty]) = self.elem_type else {
+                    unreachable!("BUG: expected map type, got {:?}", self.elem_type)
+                };
+
+                let array_end = *end_indices.next()?;
+
+                let indices = *next_start..array_end;
+
+                *next_start = array_end;
+
+                Some(
+                    T::decode_map(
+                        ArrayData {
+                            elem_type: key_ty,
+                            layout: key_layout,
+                            indices: indices.clone(),
+                        },
+                        ArrayData {
+                            elem_type: val_ty,
+                            layout: val_layout,
+                            indices,
+                        },
+                    )
+                    .map_err(Error::Other),
+                )
+            }
         }
     }
 }
 
-enum IterKind<'a> {
-    Fixed(slice::ChunksExact<'a, u8>),
-    Variable {
-        next_start: usize,
-        end_indices: slice::Iter<'a, usize>,
-        data: &'a [u8],
-    },
-    Array {
-        next_start: usize,
-        end_indices: slice::Iter<'a, usize>,
-        elem_layout: &'a Layout,
-    },
+impl<'a> TupleIter<'a> {
+    pub fn decode_next<T: Decode<'a>>(&mut self) -> Result<T, Error> {
+        let (elem_type, layout) = self.types.next().zip(self.layouts.next()).ok_or_else(|| {
+            Error::Custom("attempting to decode tuple with more types than received".into())
+        })?;
+
+        ArrayData {
+            elem_type,
+            layout,
+            // If `self.index + 1` overflows this range will be empty
+            indices: self.index..self.index + 1,
+        }
+        .into_reader::<T>()?
+        .next()
+        .ok_or_else(|| Error::Custom("attempting to decode from an empty array".into()))?
+    }
 }

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -56,6 +56,15 @@ enum IterKind<'a> {
 }
 
 impl<'a> ArrayData<'a> {
+    pub(super) fn at_index(elem_type: &'a DataTypeNode, layout: &'a Layout, index: usize) -> Self {
+        Self {
+            elem_type,
+            layout,
+            // If this overflows it'll just result in an empty range
+            indices: index..index.saturating_add(1),
+        }
+    }
+
     pub fn into_reader<T>(self) -> Result<ArrayReader<'a, T>, Error>
     where
         T: Decode<'a>,
@@ -285,13 +294,17 @@ where
                     return Some(T::decode_null(self.elem_type).map_err(Error::Other));
                 }
 
-                Some(find_lc_data(lc, inner_type, key).and_then(|data| {
-                    data.into_reader()?.next().ok_or_else(|| {
-                        Error::Custom(format!(
-                            "data for LowCardinality({inner_type}) key not found: {key}"
-                        ))
-                    })?
-                }))
+                Some(
+                    ArrayData::at_index(inner_type, &lc.dict, key)
+                        .into_reader::<T>()
+                        .and_then(|mut reader| {
+                            reader.next().ok_or_else(|| {
+                                Error::Custom(format!(
+                                    "data for LowCardinality({inner_type}) key not found: {key}"
+                                ))
+                            })?
+                        }),
+                )
             }
         }
     }
@@ -314,46 +327,9 @@ impl<'a> TupleIter<'a> {
             Error::Custom("attempting to decode tuple with more types than received".into())
         })?;
 
-        ArrayData {
-            elem_type,
-            layout,
-            // If `self.index + 1` overflows this range will be empty
-            indices: self.index..self.index + 1,
-        }
-        .into_reader::<T>()?
-        .next()
-        .ok_or_else(|| Error::Custom("attempting to decode from an empty array".into()))?
+        ArrayData::at_index(elem_type, layout, self.index)
+            .into_reader::<T>()?
+            .next()
+            .ok_or_else(|| Error::Custom("attempting to decode from an empty array".into()))?
     }
-}
-
-fn find_lc_data<'a>(
-    lc: &'a LayoutLowCardinality,
-    inner_type: &'a DataTypeNode,
-    mut key: usize,
-) -> Result<ArrayData<'a>, Error> {
-    if let Some(global_dict) = &lc.global_dict {
-        if key < global_dict.num_values {
-            return Ok(ArrayData {
-                elem_type: inner_type,
-                layout: global_dict,
-                indices: key..key + 1,
-            });
-        }
-
-        key -= global_dict.num_values;
-    }
-
-    if let Some(local_dict) = &lc.local_dict
-        && key < local_dict.num_values
-    {
-        return Ok(ArrayData {
-            elem_type: inner_type,
-            layout: local_dict,
-            indices: key..key + 1,
-        });
-    }
-
-    Err(Error::Custom(format!(
-        "key for LowCardinality({inner_type}) not in range: {key}"
-    )))
 }

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -1,0 +1,173 @@
+use crate::error::Error;
+use crate::native::Layout;
+use clickhouse_types::DataTypeNode;
+use std::marker::PhantomData;
+use std::slice;
+
+use crate::native::Decode;
+use crate::native::decode::ValueReader;
+
+pub struct ArrayReader<'a, T> {
+    elem_type: &'a DataTypeNode,
+    data: &'a [u8],
+    kind: IterKind<'a>,
+    nulls: Option<slice::Iter<'a, u8>>,
+    // covariant over `'a` and `T`
+    _marker: PhantomData<&'a T>,
+}
+
+pub struct ArrayData<'a> {
+    pub(super) elem_type: &'a DataTypeNode,
+    pub(super) layout: &'a Layout,
+    pub(super) data: &'a [u8],
+    pub(super) nulls: Option<&'a [u8]>,
+}
+
+impl<'a> ArrayData<'a> {
+    pub fn into_reader<T>(self) -> Result<ArrayReader<'a, T>, Error>
+    where
+        T: Decode<'a>,
+    {
+        if !T::compatible(self.elem_type) {
+            return Err(Error::Custom(format!(
+                "incompatible data type {}",
+                self.elem_type
+            )));
+        }
+
+        Ok(self.into_reader_unchecked())
+    }
+
+    pub(super) fn into_reader_unchecked<T>(self) -> ArrayReader<'a, T>
+    where
+        T: Decode<'a>,
+    {
+        ArrayReader {
+            elem_type: self.elem_type,
+            data: self.data,
+            kind: match *self.layout {
+                Layout::Fixed { type_width } => IterKind::Fixed(self.data.chunks_exact(type_width)),
+                Layout::Offsets(ref offsets) => IterKind::Offsets(offsets.iter()),
+                Layout::Array {
+                    ref elem_layout,
+                    cumulative_lengths: ref lengths,
+                } => IterKind::Array {
+                    next_start: 0,
+                    cumulative_lengths: lengths.iter(),
+                    elem_layout,
+                },
+                Layout::LowCardinality(_) => todo!("implement LowCardinality"),
+            },
+            nulls: self.nulls.map(|nulls| nulls.iter()),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Iterator for ArrayReader<'a, T>
+where
+    T: Decode<'a>,
+{
+    type Item = Result<T, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        macro_rules! check_null {
+            () => {
+                match self.nulls.as_mut().map(Iterator::next) {
+                    // not-null = 0x0, or no null-map
+                    Some(Some(&0)) | None => (),
+                    Some(Some(_)) => {
+                        return Some(T::decode_null(self.elem_type).map_err(Error::Other))
+                    }
+                    Some(None) => return None,
+                }
+            };
+        }
+
+        match &mut self.kind {
+            IterKind::Fixed(iter) => {
+                let native_bytes = iter.next()?;
+
+                // Need to make sure we advance the main iterator first
+                check_null!();
+
+                Some(
+                    T::decode(&mut ValueReader {
+                        data_type: self.elem_type,
+                        native_bytes,
+                    })
+                    .map_err(Error::Other),
+                )
+            }
+            IterKind::Offsets(offsets) => {
+                let start = *offsets.next()?;
+
+                // Need to make sure we advance the main iterator first
+                check_null!();
+
+                let end = offsets
+                    .as_slice()
+                    .first()
+                    .copied()
+                    .unwrap_or(self.data.len());
+
+                Some(
+                    T::decode(&mut ValueReader {
+                        data_type: self.elem_type,
+                        native_bytes: &self.data[start..end],
+                    })
+                    .map_err(Error::Other),
+                )
+            }
+            IterKind::Array {
+                next_start,
+                cumulative_lengths,
+                elem_layout,
+            } => {
+                let DataTypeNode::Array(elem_type) = self.elem_type else {
+                    unreachable!(
+                        "BUG: expected subarray element type, got {:?}",
+                        self.elem_type
+                    )
+                };
+
+                let array_end = *cumulative_lengths.next()?;
+
+                let nulls = if let Some(nulls) = &mut self.nulls {
+                    let (array_nulls, rem) = nulls
+                        .as_slice()
+                        // FIXME: checked math?
+                        .split_at(array_end - *next_start);
+
+                    *nulls = rem.iter();
+
+                    Some(array_nulls)
+                } else {
+                    None
+                };
+
+                *next_start = array_end;
+
+                Some(
+                    T::decode_array(ArrayData {
+                        elem_type,
+                        layout: elem_layout,
+                        data: self.data,
+                        nulls,
+                    })
+                    .map_err(Error::Other),
+                )
+            }
+        }
+    }
+}
+
+enum IterKind<'a> {
+    Fixed(slice::ChunksExact<'a, u8>),
+    Offsets(slice::Iter<'a, usize>),
+    Array {
+        next_start: usize,
+        cumulative_lengths: slice::Iter<'a, usize>,
+        elem_layout: &'a Layout,
+    },
+}

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -118,12 +118,19 @@ impl<'a> ArrayData<'a> {
                 LayoutKind::Array {
                     ref elem_layout,
                     ref end_indices,
-                } => IterKind::Array {
-                    elem_type: unwrap_array_type(self.elem_type).expect("BUG"),
-                    next_start: 0,
-                    end_indices: end_indices.iter(),
-                    elem_layout,
-                },
+                } => {
+                    let next_start = end_indices[..self.indices.start]
+                        .last()
+                        .copied()
+                        .unwrap_or(0);
+
+                    IterKind::Array {
+                        elem_type: unwrap_array_type(self.elem_type).expect("BUG"),
+                        next_start,
+                        end_indices: end_indices[self.indices.clone()].iter(),
+                        elem_layout,
+                    }
+                }
                 LayoutKind::Tuple { ref layouts } => IterKind::Tuple {
                     types: unwrap_tuple_type(self.elem_type).expect("BUG"),
                     layouts,
@@ -135,17 +142,22 @@ impl<'a> ArrayData<'a> {
                 } => {
                     let [key_ty, val_ty] = unwrap_map_type(self.elem_type).expect("BUG");
 
+                    let next_start = end_indices[..self.indices.start]
+                        .last()
+                        .copied()
+                        .unwrap_or(0);
+
                     IterKind::Map {
                         key_ty,
                         val_ty,
-                        next_start: 0,
+                        next_start,
                         key_val_layouts,
-                        end_indices: end_indices.iter(),
+                        end_indices: end_indices[self.indices.clone()].iter(),
                     }
                 }
                 LayoutKind::LowCardinality(ref lc) => IterKind::LowCardinality {
                     inner_type: unwrap_lc_type(self.elem_type).expect("BUG"),
-                    keys: lc.keys.iter(),
+                    keys: lc.keys[self.indices.clone()].iter(),
                     lc,
                 },
             },

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -1,7 +1,8 @@
 use crate::error::Error;
-use crate::native::Layout;
+use crate::native::{Layout, LayoutKind};
 use clickhouse_types::DataTypeNode;
 use std::marker::PhantomData;
+use std::ops::Range;
 use std::slice;
 
 use crate::native::Decode;
@@ -9,7 +10,6 @@ use crate::native::decode::ValueReader;
 
 pub struct ArrayReader<'a, T> {
     elem_type: &'a DataTypeNode,
-    data: &'a [u8],
     kind: IterKind<'a>,
     nulls: Option<slice::Iter<'a, u8>>,
     // covariant over `'a` and `T`
@@ -19,8 +19,7 @@ pub struct ArrayReader<'a, T> {
 pub struct ArrayData<'a> {
     pub(super) elem_type: &'a DataTypeNode,
     pub(super) layout: &'a Layout,
-    pub(super) data: &'a [u8],
-    pub(super) nulls: Option<&'a [u8]>,
+    pub(super) indices: Range<usize>,
 }
 
 impl<'a> ArrayData<'a> {
@@ -44,21 +43,44 @@ impl<'a> ArrayData<'a> {
     {
         ArrayReader {
             elem_type: self.elem_type,
-            data: self.data,
-            kind: match *self.layout {
-                Layout::Fixed { type_width } => IterKind::Fixed(self.data.chunks_exact(type_width)),
-                Layout::Offsets(ref offsets) => IterKind::Offsets(offsets.iter()),
-                Layout::Array {
+            kind: match self.layout.kind {
+                LayoutKind::Fixed {
+                    type_width,
+                    ref data,
+                } => IterKind::Fixed(
+                    data[self.indices.start * type_width..self.indices.end * type_width]
+                        .chunks_exact(type_width),
+                ),
+                LayoutKind::Variable {
+                    end_offsets: ref end_indices,
+                    ref data,
+                } => {
+                    let next_start = end_indices[..self.indices.start]
+                        .last()
+                        .copied()
+                        .unwrap_or(0);
+
+                    IterKind::Variable {
+                        next_start,
+                        end_indices: end_indices[self.indices.clone()].iter(),
+                        data,
+                    }
+                }
+                LayoutKind::Array {
                     ref elem_layout,
-                    cumulative_lengths: ref lengths,
+                    ref end_indices,
                 } => IterKind::Array {
                     next_start: 0,
-                    cumulative_lengths: lengths.iter(),
+                    end_indices: end_indices.iter(),
                     elem_layout,
                 },
-                Layout::LowCardinality(_) => todo!("implement LowCardinality"),
+                LayoutKind::LowCardinality(_) => todo!("implement LowCardinality"),
             },
-            nulls: self.nulls.map(|nulls| nulls.iter()),
+            nulls: self
+                .layout
+                .nulls
+                .as_ref()
+                .map(|nulls| nulls[self.indices].iter()),
             _marker: PhantomData,
         }
     }
@@ -99,29 +121,30 @@ where
                     .map_err(Error::Other),
                 )
             }
-            IterKind::Offsets(offsets) => {
-                let start = *offsets.next()?;
+            IterKind::Variable {
+                next_start,
+                end_indices,
+                data,
+            } => {
+                let end = *end_indices.next()?;
+
+                let start = *next_start;
+                *next_start = end;
 
                 // Need to make sure we advance the main iterator first
                 check_null!();
 
-                let end = offsets
-                    .as_slice()
-                    .first()
-                    .copied()
-                    .unwrap_or(self.data.len());
-
                 Some(
                     T::decode(&mut ValueReader {
                         data_type: self.elem_type,
-                        native_bytes: &self.data[start..end],
+                        native_bytes: &data[start..end],
                     })
                     .map_err(Error::Other),
                 )
             }
             IterKind::Array {
                 next_start,
-                cumulative_lengths,
+                end_indices,
                 elem_layout,
             } => {
                 let DataTypeNode::Array(elem_type) = self.elem_type else {
@@ -131,20 +154,9 @@ where
                     )
                 };
 
-                let array_end = *cumulative_lengths.next()?;
+                let array_end = *end_indices.next()?;
 
-                let nulls = if let Some(nulls) = &mut self.nulls {
-                    let (array_nulls, rem) = nulls
-                        .as_slice()
-                        // FIXME: checked math?
-                        .split_at(array_end - *next_start);
-
-                    *nulls = rem.iter();
-
-                    Some(array_nulls)
-                } else {
-                    None
-                };
+                let indices = *next_start..array_end;
 
                 *next_start = array_end;
 
@@ -152,8 +164,7 @@ where
                     T::decode_array(ArrayData {
                         elem_type,
                         layout: elem_layout,
-                        data: self.data,
-                        nulls,
+                        indices,
                     })
                     .map_err(Error::Other),
                 )
@@ -164,10 +175,14 @@ where
 
 enum IterKind<'a> {
     Fixed(slice::ChunksExact<'a, u8>),
-    Offsets(slice::Iter<'a, usize>),
+    Variable {
+        next_start: usize,
+        end_indices: slice::Iter<'a, usize>,
+        data: &'a [u8],
+    },
     Array {
         next_start: usize,
-        cumulative_lengths: slice::Iter<'a, usize>,
+        end_indices: slice::Iter<'a, usize>,
         elem_layout: &'a Layout,
     },
 }

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -295,6 +295,17 @@ where
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.kind {
+            IterKind::Fixed(chunks) => chunks.size_hint(),
+            IterKind::Variable { end_indices, .. } => end_indices.size_hint(),
+            IterKind::Array { end_indices, .. } => end_indices.size_hint(),
+            IterKind::Tuple { elem_indices, .. } => elem_indices.size_hint(),
+            IterKind::Map { end_indices, .. } => end_indices.size_hint(),
+            IterKind::LowCardinality { keys, .. } => keys.size_hint(),
+        }
+    }
 }
 
 impl<'a> TupleIter<'a> {

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -83,8 +83,16 @@ impl<'a> ArrayData<'a> {
     where
         T: Decode<'a>,
     {
+        // Lift all "simple" wrappers
+        let elem_type = match self.elem_type {
+            DataTypeNode::Nullable(inner) => inner,
+            DataTypeNode::SimpleAggregateFunction(_, inner) => inner,
+            // LowCardinality has special handling
+            other => other,
+        };
+
         ArrayReader {
-            elem_type: self.elem_type,
+            elem_type,
             kind: match self.layout.kind {
                 LayoutKind::Fixed {
                     type_width,
@@ -281,7 +289,10 @@ where
             }
             IterKind::LowCardinality { keys, lc } => {
                 let DataTypeNode::LowCardinality(inner_type) = self.elem_type else {
-                    unreachable!("BUG: expected map type, got {:?}", self.elem_type)
+                    unreachable!(
+                        "BUG: expected LowCardinality type, got {:?}",
+                        self.elem_type
+                    )
                 };
 
                 let key = *keys.next()?;

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::native::{Layout, LayoutKind};
+use crate::native::{Layout, LayoutKind, LayoutLowCardinality};
 use clickhouse_types::DataTypeNode;
 use std::marker::PhantomData;
 use std::ops::Range;
@@ -49,6 +49,10 @@ enum IterKind<'a> {
         end_indices: slice::Iter<'a, usize>,
         key_val_layouts: &'a [Layout; 2],
     },
+    LowCardinality {
+        keys: slice::Iter<'a, usize>,
+        lc: &'a LayoutLowCardinality,
+    },
 }
 
 impl<'a> ArrayData<'a> {
@@ -56,7 +60,7 @@ impl<'a> ArrayData<'a> {
     where
         T: Decode<'a>,
     {
-        if !T::compatible(self.elem_type) {
+        if !T::compatible(self.elem_type.remove_low_cardinality()) {
             return Err(Error::Custom(format!(
                 "incompatible data type {}",
                 self.elem_type
@@ -115,7 +119,10 @@ impl<'a> ArrayData<'a> {
                     key_val_layouts,
                     end_indices: end_indices.iter(),
                 },
-                LayoutKind::LowCardinality(_) => todo!("implement LowCardinality"),
+                LayoutKind::LowCardinality(ref lc) => IterKind::LowCardinality {
+                    keys: lc.keys.iter(),
+                    lc,
+                },
             },
             nulls: self
                 .layout
@@ -263,6 +270,29 @@ where
                     .map_err(Error::Other),
                 )
             }
+            IterKind::LowCardinality { keys, lc } => {
+                let DataTypeNode::LowCardinality(inner_type) = self.elem_type else {
+                    unreachable!("BUG: expected map type, got {:?}", self.elem_type)
+                };
+
+                let key = *keys.next()?;
+
+                // Check the null map in case of `Nullable(LowCardinality(...))`
+                check_null!();
+
+                // `key = 0` is the NULL placeholder
+                if lc.is_nullable && key == 0 {
+                    return Some(T::decode_null(self.elem_type).map_err(Error::Other));
+                }
+
+                Some(find_lc_data(lc, inner_type, key).and_then(|data| {
+                    data.into_reader()?.next().ok_or_else(|| {
+                        Error::Custom(format!(
+                            "data for LowCardinality({inner_type}) key not found: {key}"
+                        ))
+                    })?
+                }))
+            }
         }
     }
 }
@@ -283,4 +313,36 @@ impl<'a> TupleIter<'a> {
         .next()
         .ok_or_else(|| Error::Custom("attempting to decode from an empty array".into()))?
     }
+}
+
+fn find_lc_data<'a>(
+    lc: &'a LayoutLowCardinality,
+    inner_type: &'a DataTypeNode,
+    mut key: usize,
+) -> Result<ArrayData<'a>, Error> {
+    if let Some(global_dict) = &lc.global_dict {
+        if key < global_dict.num_values {
+            return Ok(ArrayData {
+                elem_type: inner_type,
+                layout: global_dict,
+                indices: key..key + 1,
+            });
+        }
+
+        key -= global_dict.num_values;
+    }
+
+    if let Some(local_dict) = &lc.local_dict
+        && key < local_dict.num_values
+    {
+        return Ok(ArrayData {
+            elem_type: inner_type,
+            layout: local_dict,
+            indices: key..key + 1,
+        });
+    }
+
+    Err(Error::Custom(format!(
+        "key for LowCardinality({inner_type}) not in range: {key}"
+    )))
 }

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -36,20 +36,27 @@ enum IterKind<'a> {
         data: &'a [u8],
     },
     Array {
+        // To avoid having to recurse into `DataTypeNode` every time,
+        // we memoize what the element type is
+        elem_type: &'a DataTypeNode,
         next_start: usize,
         end_indices: slice::Iter<'a, usize>,
         elem_layout: &'a Layout,
     },
     Tuple {
+        types: &'a [DataTypeNode],
         layouts: &'a [Layout],
         elem_indices: Range<usize>,
     },
     Map {
+        key_ty: &'a DataTypeNode,
+        val_ty: &'a DataTypeNode,
         next_start: usize,
         end_indices: slice::Iter<'a, usize>,
         key_val_layouts: &'a [Layout; 2],
     },
     LowCardinality {
+        inner_type: &'a DataTypeNode,
         keys: slice::Iter<'a, usize>,
         lc: &'a LayoutLowCardinality,
     },
@@ -83,16 +90,8 @@ impl<'a> ArrayData<'a> {
     where
         T: Decode<'a>,
     {
-        // Lift all "simple" wrappers
-        let elem_type = match self.elem_type {
-            DataTypeNode::Nullable(inner) => inner,
-            DataTypeNode::SimpleAggregateFunction(_, inner) => inner,
-            // LowCardinality has special handling
-            other => other,
-        };
-
         ArrayReader {
-            elem_type,
+            elem_type: self.elem_type,
             kind: match self.layout.kind {
                 LayoutKind::Fixed {
                     type_width,
@@ -120,23 +119,32 @@ impl<'a> ArrayData<'a> {
                     ref elem_layout,
                     ref end_indices,
                 } => IterKind::Array {
+                    elem_type: unwrap_array_type(self.elem_type).expect("BUG"),
                     next_start: 0,
                     end_indices: end_indices.iter(),
                     elem_layout,
                 },
                 LayoutKind::Tuple { ref layouts } => IterKind::Tuple {
+                    types: unwrap_tuple_type(self.elem_type).expect("BUG"),
                     layouts,
                     elem_indices: self.indices.clone(),
                 },
                 LayoutKind::Map {
                     ref key_val_layouts,
                     ref end_indices,
-                } => IterKind::Map {
-                    next_start: 0,
-                    key_val_layouts,
-                    end_indices: end_indices.iter(),
-                },
+                } => {
+                    let [key_ty, val_ty] = unwrap_map_type(self.elem_type).expect("BUG");
+
+                    IterKind::Map {
+                        key_ty,
+                        val_ty,
+                        next_start: 0,
+                        key_val_layouts,
+                        end_indices: end_indices.iter(),
+                    }
+                }
                 LayoutKind::LowCardinality(ref lc) => IterKind::LowCardinality {
+                    inner_type: unwrap_lc_type(self.elem_type).expect("BUG"),
                     keys: lc.keys.iter(),
                     lc,
                 },
@@ -208,17 +216,11 @@ where
                 )
             }
             IterKind::Array {
+                elem_type,
                 next_start,
                 end_indices,
                 elem_layout,
             } => {
-                let DataTypeNode::Array(elem_type) = self.elem_type else {
-                    unreachable!(
-                        "BUG: expected subarray element type, got {:?}",
-                        self.elem_type
-                    )
-                };
-
                 let array_end = *end_indices.next()?;
 
                 let indices = *next_start..array_end;
@@ -235,13 +237,10 @@ where
                 )
             }
             IterKind::Tuple {
+                types,
                 layouts,
                 elem_indices,
             } => {
-                let DataTypeNode::Tuple(types) = self.elem_type else {
-                    unreachable!("BUG: expected tuple type, got {:?}", self.elem_type)
-                };
-
                 let index = elem_indices.next()?;
 
                 // Need to make sure we advance the main iterator first
@@ -257,14 +256,12 @@ where
                 )
             }
             IterKind::Map {
+                key_ty,
+                val_ty,
                 next_start,
                 end_indices,
                 key_val_layouts: [key_layout, val_layout],
             } => {
-                let DataTypeNode::Map([key_ty, val_ty]) = self.elem_type else {
-                    unreachable!("BUG: expected map type, got {:?}", self.elem_type)
-                };
-
                 let array_end = *end_indices.next()?;
 
                 let indices = *next_start..array_end;
@@ -287,14 +284,11 @@ where
                     .map_err(Error::Other),
                 )
             }
-            IterKind::LowCardinality { keys, lc } => {
-                let DataTypeNode::LowCardinality(inner_type) = self.elem_type else {
-                    unreachable!(
-                        "BUG: expected LowCardinality type, got {:?}",
-                        self.elem_type
-                    )
-                };
-
+            IterKind::LowCardinality {
+                inner_type,
+                keys,
+                lc,
+            } => {
                 let key = *keys.next()?;
 
                 // Check the null map in case of `Nullable(LowCardinality(...))`
@@ -342,5 +336,53 @@ impl<'a> TupleIter<'a> {
             .into_reader::<T>()?
             .next()
             .ok_or_else(|| Error::Custom("attempting to decode from an empty array".into()))?
+    }
+}
+
+fn unwrap_array_type(data_type: &DataTypeNode) -> Result<&DataTypeNode, Error> {
+    match data_type {
+        DataTypeNode::Array(elem_type) => Ok(elem_type),
+        DataTypeNode::Nullable(inner) | DataTypeNode::SimpleAggregateFunction(_, inner) => {
+            unwrap_array_type(inner)
+        }
+        _ => Err(Error::Custom(format!(
+            "expected Array type, got {data_type}"
+        ))),
+    }
+}
+
+fn unwrap_tuple_type(data_type: &DataTypeNode) -> Result<&[DataTypeNode], Error> {
+    match data_type {
+        DataTypeNode::Tuple(types) => Ok(types),
+        DataTypeNode::Nullable(inner) | DataTypeNode::SimpleAggregateFunction(_, inner) => {
+            unwrap_tuple_type(inner)
+        }
+        _ => Err(Error::Custom(format!(
+            "expected Tuple type, got {data_type}"
+        ))),
+    }
+}
+
+fn unwrap_map_type(data_type: &DataTypeNode) -> Result<&[Box<DataTypeNode>; 2], Error> {
+    match data_type {
+        DataTypeNode::Map(types) => Ok(types),
+        DataTypeNode::Nullable(inner) | DataTypeNode::SimpleAggregateFunction(_, inner) => {
+            unwrap_map_type(inner)
+        }
+        _ => Err(Error::Custom(format!(
+            "expected Tuple type, got {data_type}"
+        ))),
+    }
+}
+
+fn unwrap_lc_type(data_type: &DataTypeNode) -> Result<&DataTypeNode, Error> {
+    match data_type {
+        DataTypeNode::LowCardinality(elem_type) => Ok(elem_type),
+        DataTypeNode::Nullable(inner) | DataTypeNode::SimpleAggregateFunction(_, inner) => {
+            unwrap_array_type(inner)
+        }
+        _ => Err(Error::Custom(format!(
+            "expected LowCardinality type, got {data_type}"
+        ))),
     }
 }

--- a/src/native/array.rs
+++ b/src/native/array.rs
@@ -77,7 +77,7 @@ impl<'a> ArrayData<'a> {
         T: Decode<'a>,
     {
         if !T::compatible(self.elem_type.remove_low_cardinality()) {
-            return Err(Error::Custom(format!(
+            return Err(Error::SchemaMismatch(format!(
                 "incompatible data type {}",
                 self.elem_type
             )));
@@ -316,9 +316,12 @@ where
                         .into_reader::<T>()
                         .and_then(|mut reader| {
                             reader.next().ok_or_else(|| {
-                                Error::Custom(format!(
-                                    "data for LowCardinality({inner_type}) key not found: {key}"
-                                ))
+                                Error::DataFormat(
+                                    format!(
+                                        "data for LowCardinality({inner_type}) key not found: {key}"
+                                    )
+                                    .into(),
+                                )
                             })?
                         }),
                 )
@@ -341,13 +344,15 @@ where
 impl<'a> TupleIter<'a> {
     pub fn decode_next<T: Decode<'a>>(&mut self) -> Result<T, Error> {
         let (elem_type, layout) = self.types.next().zip(self.layouts.next()).ok_or_else(|| {
-            Error::Custom("attempting to decode tuple with more types than received".into())
+            Error::SchemaMismatch("attempting to decode tuple with more types than received".into())
         })?;
 
         ArrayData::at_index(elem_type, layout, self.index)
             .into_reader::<T>()?
             .next()
-            .ok_or_else(|| Error::Custom("attempting to decode from an empty array".into()))?
+            .ok_or_else(|| {
+                Error::SchemaMismatch("attempting to decode from an empty array".into())
+            })?
     }
 }
 
@@ -357,7 +362,7 @@ fn unwrap_array_type(data_type: &DataTypeNode) -> Result<&DataTypeNode, Error> {
         DataTypeNode::Nullable(inner) | DataTypeNode::SimpleAggregateFunction(_, inner) => {
             unwrap_array_type(inner)
         }
-        _ => Err(Error::Custom(format!(
+        _ => Err(Error::SchemaMismatch(format!(
             "expected Array type, got {data_type}"
         ))),
     }
@@ -369,7 +374,7 @@ fn unwrap_tuple_type(data_type: &DataTypeNode) -> Result<&[DataTypeNode], Error>
         DataTypeNode::Nullable(inner) | DataTypeNode::SimpleAggregateFunction(_, inner) => {
             unwrap_tuple_type(inner)
         }
-        _ => Err(Error::Custom(format!(
+        _ => Err(Error::SchemaMismatch(format!(
             "expected Tuple type, got {data_type}"
         ))),
     }
@@ -381,7 +386,7 @@ fn unwrap_map_type(data_type: &DataTypeNode) -> Result<&[Box<DataTypeNode>; 2], 
         DataTypeNode::Nullable(inner) | DataTypeNode::SimpleAggregateFunction(_, inner) => {
             unwrap_map_type(inner)
         }
-        _ => Err(Error::Custom(format!(
+        _ => Err(Error::SchemaMismatch(format!(
             "expected Tuple type, got {data_type}"
         ))),
     }
@@ -393,7 +398,7 @@ fn unwrap_lc_type(data_type: &DataTypeNode) -> Result<&DataTypeNode, Error> {
         DataTypeNode::Nullable(inner) | DataTypeNode::SimpleAggregateFunction(_, inner) => {
             unwrap_array_type(inner)
         }
-        _ => Err(Error::Custom(format!(
+        _ => Err(Error::SchemaMismatch(format!(
             "expected LowCardinality type, got {data_type}"
         ))),
     }

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -1,6 +1,8 @@
-use crate::native::array::ArrayData;
+use crate::native::array::{ArrayData, TupleIter};
 use clickhouse_types::DataTypeNode;
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
+use std::hash::{BuildHasher, Hash};
 
 pub struct ValueReader<'a> {
     pub(super) data_type: &'a DataTypeNode,
@@ -33,7 +35,7 @@ pub enum ValueReadError {
     InvalidLength { expected: usize, actual: usize },
 }
 
-pub trait Decode<'a>: Sized {
+pub trait Decode<'a>: 'a + Sized {
     fn compatible(data_type: &DataTypeNode) -> bool;
 
     fn decode(reader: &mut ValueReader<'a>)
@@ -48,17 +50,20 @@ pub trait Decode<'a>: Sized {
     fn decode_array(data: ArrayData<'a>) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
         Err(format!("unexpected data type Array({})", data.elem_type).into())
     }
-}
 
-impl<'a> Decode<'a> for u64 {
-    fn compatible(data_type: &DataTypeNode) -> bool {
-        matches!(data_type, DataTypeNode::UInt64)
+    fn decode_tuple(data: TupleIter<'a>) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Err(format!("unexpected data type Tuple({:?})", data.types.as_slice()).into())
     }
 
-    fn decode(
-        reader: &mut ValueReader<'a>,
+    fn decode_map(
+        key_data: ArrayData<'a>,
+        value_data: ArrayData<'a>,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-        Ok(u64::from_le_bytes(*reader.read_bytes_fixed()?))
+        Err(format!(
+            "unexpected data type Map({}, {})",
+            key_data.elem_type, value_data.elem_type
+        )
+        .into())
     }
 }
 
@@ -128,6 +133,14 @@ impl<'a, T: Decode<'a>> Decode<'a> for Option<T> {
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
         Ok(None)
     }
+
+    fn decode_array(data: ArrayData<'a>) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        T::decode_array(data).map(Some)
+    }
+
+    fn decode_tuple(data: TupleIter<'a>) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        T::decode_tuple(data).map(Some)
+    }
 }
 
 // FIXME: need to decide if `Vec<u8>` corresponds to `String` or `Array<UInt8>`
@@ -150,5 +163,145 @@ impl<'a, T: Decode<'a> + 'a> Decode<'a> for Vec<T> {
         data.into_reader::<T>()?
             .collect::<Result<Vec<T>, crate::Error>>()
             .map_err(Into::into)
+    }
+}
+
+macro_rules! tuple_impl {
+    ($var1:ident: $ty1:ident $(, $var:ident: $ty:ident)*) => {
+        impl<'a, $ty1 $(, $ty)* > Decode<'a> for ($ty1, $($ty),*)
+            where
+                $ty1: Decode<'a>,
+                $($ty: Decode<'a>,)*
+        {
+            fn compatible(data_type: &DataTypeNode) -> bool {
+                let DataTypeNode::Tuple(types) = data_type else {
+                    return false;
+                };
+
+                // Matches exact length of array
+                let [$var1 $(, $var)*] = &types[..] else {
+                    return false;
+                };
+
+                <$ty1 as Decode>::compatible($var1)
+                $(&& <$ty as Decode>::compatible($var))*
+
+            }
+
+            fn decode(
+                reader: &mut ValueReader<'a>,
+            ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+                Err(format!("expected array type, got {}", reader.data_type).into())
+            }
+
+            fn decode_tuple(mut data: TupleIter<'a>) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+                Ok((
+                    data.decode_next::<$ty1>()?,
+                    $(data.decode_next::<$ty>()?),*
+                ))
+            }
+        }
+
+        tuple_impl!($($var: $ty),*);
+    };
+    () => {}
+}
+
+tuple_impl!(t1: T1, t2: T2, t3: T3);
+
+macro_rules! impl_from_le_bytes {
+    ($($dataty:ident: $ty:ident),* $(,)?) => {
+        $(
+            impl<'a> Decode<'a> for $ty {
+                fn compatible(data_type: &DataTypeNode) -> bool {
+                    matches!(data_type, DataTypeNode::$dataty)
+                }
+
+                fn decode(
+                    reader: &mut ValueReader<'a>,
+                ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+                    Ok($ty::from_le_bytes(*reader.read_bytes_fixed()?))
+                }
+            }
+        )*
+    };
+}
+
+// All scalar primitives are in little-endian
+impl_from_le_bytes!(
+    Int8: i8,
+    Int16: i16,
+    Int32: i32,
+    Int64: i64,
+    Int128: i128,
+    UInt8: u8,
+    UInt16: u16,
+    UInt32: u32,
+    UInt64: u64,
+    UInt128: u128,
+    Float32: f32,
+    Float64: f64,
+);
+
+impl<'a, K, V, S> Decode<'a> for HashMap<K, V, S>
+where
+    K: Decode<'a> + Hash + Eq,
+    V: Decode<'a>,
+    S: BuildHasher + Default + 'a,
+{
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        let DataTypeNode::Map([key_ty, val_ty]) = data_type else {
+            return false;
+        };
+
+        K::compatible(key_ty) && V::compatible(val_ty)
+    }
+
+    fn decode(
+        reader: &mut ValueReader<'a>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Err(format!("expected map, got {}", reader.data_type).into())
+    }
+
+    fn decode_map(
+        key_data: ArrayData<'a>,
+        value_data: ArrayData<'a>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        key_data
+            .into_reader::<K>()?
+            .zip(value_data.into_reader::<V>()?)
+            .map(|(k, v)| Ok((k?, v?)))
+            .collect::<Result<Self, Box<dyn Error + Send + Sync + 'static>>>()
+    }
+}
+
+impl<'a, K, V> Decode<'a> for BTreeMap<K, V>
+where
+    K: Decode<'a> + Ord + Eq,
+    V: Decode<'a>,
+{
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        let DataTypeNode::Map([key_ty, val_ty]) = data_type else {
+            return false;
+        };
+
+        K::compatible(key_ty) && V::compatible(val_ty)
+    }
+
+    fn decode(
+        reader: &mut ValueReader<'a>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Err(format!("expected map, got {}", reader.data_type).into())
+    }
+
+    fn decode_map(
+        key_data: ArrayData<'a>,
+        value_data: ArrayData<'a>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        key_data
+            .into_reader::<K>()?
+            .zip(value_data.into_reader::<V>()?)
+            .map(|(k, v)| Ok((k?, v?)))
+            .collect::<Result<Self, Box<dyn Error + Send + Sync + 'static>>>()
     }
 }

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -68,6 +68,56 @@ pub trait Decode<'a>: 'a + Sized {
     }
 }
 
+macro_rules! impl_from_le_bytes {
+    ($($dataty:ident: $ty:ident),* $(,)?) => {
+        $(
+            impl<'a> Decode<'a> for $ty {
+                fn compatible(data_type: &DataTypeNode) -> bool {
+                    matches!(data_type, DataTypeNode::$dataty)
+                }
+
+                fn decode(
+                    reader: &mut ValueReader<'a>,
+                ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+                    Ok($ty::from_le_bytes(*reader.read_bytes_fixed()?))
+                }
+            }
+        )*
+    };
+}
+
+// All scalar primitives are in little-endian
+impl_from_le_bytes!(
+    // 8-bit ints don't have a concept of "endianness" but they still implement `from_bytes_le()`
+    // for the express purpose of being included in macros like this
+    Int8: i8,
+    Int16: i16,
+    Int32: i32,
+    Int64: i64,
+    Int128: i128,
+    UInt8: u8,
+    UInt16: u16,
+    UInt32: u32,
+    UInt64: u64,
+    UInt128: u128,
+    Float32: f32,
+    Float64: f64,
+);
+
+impl Decode<'_> for bool {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        matches!(data_type, DataTypeNode::Bool)
+    }
+
+    fn decode(
+        reader: &mut ValueReader<'_>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        // https://clickhouse.com/docs/interfaces/specs/NativeFormat#bool
+        let [b] = reader.read_bytes_fixed()?;
+        Ok(*b != 0)
+    }
+}
+
 impl<'a> Decode<'a> for &'a str {
     fn compatible(data_type: &DataTypeNode) -> bool {
         <&[u8] as Decode>::compatible(data_type)
@@ -209,40 +259,6 @@ macro_rules! tuple_impl {
 }
 
 tuple_impl!(t1: T1, t2: T2, t3: T3);
-
-macro_rules! impl_from_le_bytes {
-    ($($dataty:ident: $ty:ident),* $(,)?) => {
-        $(
-            impl<'a> Decode<'a> for $ty {
-                fn compatible(data_type: &DataTypeNode) -> bool {
-                    matches!(data_type, DataTypeNode::$dataty)
-                }
-
-                fn decode(
-                    reader: &mut ValueReader<'a>,
-                ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-                    Ok($ty::from_le_bytes(*reader.read_bytes_fixed()?))
-                }
-            }
-        )*
-    };
-}
-
-// All scalar primitives are in little-endian
-impl_from_le_bytes!(
-    Int8: i8,
-    Int16: i16,
-    Int32: i32,
-    Int64: i64,
-    Int128: i128,
-    UInt8: u8,
-    UInt16: u16,
-    UInt32: u32,
-    UInt64: u64,
-    UInt128: u128,
-    Float32: f32,
-    Float64: f64,
-);
 
 impl<'a, K, V, S> Decode<'a> for HashMap<K, V, S>
 where

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -1,0 +1,84 @@
+use crate::native::reader::parse_varuint;
+use clickhouse_types::DataTypeNode;
+use std::error::Error;
+use std::ops::ControlFlow;
+
+pub trait Decode<'a>: Sized {
+    fn compatible(data_type: &DataTypeNode) -> bool;
+
+    fn decode(
+        data_type: &DataTypeNode,
+        native_bytes: &'a [u8],
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>>;
+}
+
+impl<'a> Decode<'a> for u64 {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        matches!(data_type, DataTypeNode::UInt64)
+    }
+
+    fn decode(
+        _data_type: &DataTypeNode,
+        native_bytes: &'a [u8],
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Ok(u64::from_le_bytes(native_bytes.try_into().map_err(
+            |_| format!("expected 8 bytes, got {}", native_bytes.len()),
+        )?))
+    }
+}
+
+impl<'a> Decode<'a> for &'a str {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        <&[u8] as Decode>::compatible(data_type)
+    }
+
+    fn decode(
+        data_type: &DataTypeNode,
+        native_bytes: &'a [u8],
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        let s = <&[u8] as Decode>::decode(data_type, native_bytes)?;
+        Ok(str::from_utf8(s)?)
+    }
+}
+
+impl<'a> Decode<'a> for &'a [u8] {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        matches!(
+            data_type,
+            DataTypeNode::String | DataTypeNode::FixedString(_)
+        )
+    }
+
+    fn decode(
+        data_type: &DataTypeNode,
+        mut native_bytes: &'a [u8],
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        let len = if let DataTypeNode::FixedString(len) = *data_type {
+            len
+        } else {
+            let len = match parse_varuint(&mut native_bytes) {
+                ControlFlow::Break(Ok(len)) => len,
+                ControlFlow::Break(Err(e)) => return Err(e.into()),
+                ControlFlow::Continue(_) => {
+                    return Err(format!(
+                        "missing terminating byte in VarUInt encoding: {native_bytes:?}"
+                    )
+                    .into());
+                }
+            };
+
+            usize::try_from(len)
+                .map_err(|_| format!("length prefix of String out of range: {len}"))?
+        };
+
+        if len != native_bytes.len() {
+            return Err(format!(
+                "length of {data_type} does not match remaining length of buffer: {len} vs {}",
+                native_bytes.len()
+            )
+            .into());
+        }
+
+        Ok(native_bytes)
+    }
+}

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -3,6 +3,7 @@ use clickhouse_types::DataTypeNode;
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::hash::{BuildHasher, Hash};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 pub struct ValueReader<'a> {
     pub(super) data_type: &'a DataTypeNode,
@@ -303,5 +304,76 @@ where
             .zip(value_data.into_reader::<V>()?)
             .map(|(k, v)| Ok((k?, v?)))
             .collect::<Result<Self, Box<dyn Error + Send + Sync + 'static>>>()
+    }
+}
+
+impl Decode<'_> for Ipv4Addr {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        matches!(data_type, DataTypeNode::IPv4)
+    }
+
+    fn decode(
+        reader: &mut ValueReader<'_>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        // https://clickhouse.com/docs/interfaces/specs/NativeFormat#ipv4-and-ipv6
+        // IPv4 is byte-reversed, so little-endian
+        let bytes_le = u32::from_le_bytes(*reader.read_bytes_fixed()?);
+        Ok(Ipv4Addr::from(bytes_le.to_be()))
+    }
+}
+
+impl Decode<'_> for Ipv6Addr {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        matches!(data_type, DataTypeNode::IPv6)
+    }
+
+    fn decode(
+        reader: &mut ValueReader<'_>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        // https://clickhouse.com/docs/interfaces/specs/NativeFormat#ipv4-and-ipv6
+        // IPv6 uses canonical (big-endian) encoding
+        Ok(Ipv6Addr::from(*reader.read_bytes_fixed::<16>()?))
+    }
+}
+
+impl Decode<'_> for IpAddr {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        matches!(data_type, DataTypeNode::IPv4 | DataTypeNode::IPv6)
+    }
+
+    fn decode(
+        reader: &mut ValueReader<'_>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        match reader.data_type {
+            DataTypeNode::IPv4 => Ipv4Addr::decode(reader).map(Into::into),
+            DataTypeNode::IPv6 => Ipv6Addr::decode(reader).map(Into::into),
+            other => Err(format!("expected IP address, got {other}").into()),
+        }
+    }
+}
+
+#[cfg(feature = "uuid")]
+mod uuid {
+    use super::{Decode, ValueReader};
+    use clickhouse_types::DataTypeNode;
+    use std::error::Error;
+    use uuid::Uuid;
+
+    impl Decode<'_> for Uuid {
+        fn compatible(data_type: &DataTypeNode) -> bool {
+            matches!(data_type, DataTypeNode::UUID)
+        }
+
+        fn decode(
+            reader: &mut ValueReader<'_>,
+        ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+            // https://clickhouse.com/docs/interfaces/specs/NativeFormat#uuid
+            // Wire bytes 0..7 = canonical bytes 0..7 reversed.
+            // Wire bytes 8..15 = canonical bytes 8..15 reversed.
+            let hi_bytes = u64::from_le_bytes(*reader.read_bytes_fixed()?);
+            let low_bytes = u64::from_le_bytes(*reader.read_bytes_fixed()?);
+
+            Ok(Uuid::from_u64_pair(hi_bytes.to_be(), low_bytes.to_be()))
+        }
     }
 }

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -68,12 +68,27 @@ pub trait Decode<'a>: 'a + Sized {
     }
 }
 
+macro_rules! type_matches {
+    ($data_type:expr, $data_type_pat:pat) => {
+        match &$data_type {
+            $data_type_pat => true,
+            $crate::native::DataTypeNode::LowCardinality(inner) => {
+                matches!(**inner, $data_type_pat)
+            }
+            $crate::native::DataTypeNode::SimpleAggregateFunction(_, inner) => {
+                matches!(**inner, $data_type_pat)
+            }
+            _ => false,
+        }
+    };
+}
+
 macro_rules! impl_from_le_bytes {
     ($($dataty:ident: $ty:ident),* $(,)?) => {
         $(
             impl<'a> Decode<'a> for $ty {
                 fn compatible(data_type: &DataTypeNode) -> bool {
-                    matches!(data_type, DataTypeNode::$dataty)
+                    type_matches!(data_type, DataTypeNode::$dataty)
                 }
 
                 fn decode(
@@ -106,7 +121,7 @@ impl_from_le_bytes!(
 
 impl Decode<'_> for bool {
     fn compatible(data_type: &DataTypeNode) -> bool {
-        matches!(data_type, DataTypeNode::Bool)
+        type_matches!(data_type, DataTypeNode::Bool)
     }
 
     fn decode(
@@ -144,7 +159,7 @@ impl<'a> Decode<'a> for String {
 
 impl<'a> Decode<'a> for &'a [u8] {
     fn compatible(data_type: &DataTypeNode) -> bool {
-        matches!(
+        type_matches!(
             data_type,
             DataTypeNode::String | DataTypeNode::FixedString(_)
         )
@@ -198,7 +213,7 @@ impl<'a, T: Decode<'a>> Decode<'a> for Option<T> {
 impl<'a, T: Decode<'a> + 'a> Decode<'a> for Vec<T> {
     fn compatible(data_type: &DataTypeNode) -> bool {
         if let DataTypeNode::Array(elem_type) = data_type {
-            T::compatible(elem_type)
+            T::compatible(elem_type.remove_low_cardinality())
         } else {
             false
         }
@@ -234,8 +249,8 @@ macro_rules! tuple_impl {
                     return false;
                 };
 
-                <$ty1 as Decode>::compatible($var1)
-                $(&& <$ty as Decode>::compatible($var))*
+                <$ty1 as Decode>::compatible($var1.remove_low_cardinality())
+                $(&& <$ty as Decode>::compatible($var.remove_low_cardinality()))*
 
             }
 
@@ -271,7 +286,8 @@ where
             return false;
         };
 
-        K::compatible(key_ty) && V::compatible(val_ty)
+        K::compatible(key_ty.remove_low_cardinality())
+            && V::compatible(val_ty.remove_low_cardinality())
     }
 
     fn decode(
@@ -302,7 +318,8 @@ where
             return false;
         };
 
-        K::compatible(key_ty) && V::compatible(val_ty)
+        K::compatible(key_ty.remove_low_cardinality())
+            && V::compatible(val_ty.remove_low_cardinality())
     }
 
     fn decode(
@@ -325,7 +342,7 @@ where
 
 impl Decode<'_> for Ipv4Addr {
     fn compatible(data_type: &DataTypeNode) -> bool {
-        matches!(data_type, DataTypeNode::IPv4)
+        type_matches!(data_type, DataTypeNode::IPv4)
     }
 
     fn decode(
@@ -340,7 +357,7 @@ impl Decode<'_> for Ipv4Addr {
 
 impl Decode<'_> for Ipv6Addr {
     fn compatible(data_type: &DataTypeNode) -> bool {
-        matches!(data_type, DataTypeNode::IPv6)
+        type_matches!(data_type, DataTypeNode::IPv6)
     }
 
     fn decode(
@@ -354,7 +371,7 @@ impl Decode<'_> for Ipv6Addr {
 
 impl Decode<'_> for IpAddr {
     fn compatible(data_type: &DataTypeNode) -> bool {
-        matches!(data_type, DataTypeNode::IPv4 | DataTypeNode::IPv6)
+        type_matches!(data_type, DataTypeNode::IPv4 | DataTypeNode::IPv6)
     }
 
     fn decode(
@@ -377,7 +394,7 @@ mod uuid {
 
     impl Decode<'_> for Uuid {
         fn compatible(data_type: &DataTypeNode) -> bool {
-            matches!(data_type, DataTypeNode::UUID)
+            type_matches!(data_type, DataTypeNode::UUID)
         }
 
         fn decode(

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -1,20 +1,54 @@
+use crate::native::array::ArrayData;
 use crate::native::reader::parse_varuint;
 use clickhouse_types::DataTypeNode;
 use std::error::Error;
 use std::ops::ControlFlow;
 
+pub struct ValueReader<'a> {
+    pub(super) data_type: &'a DataTypeNode,
+    pub(super) native_bytes: &'a [u8],
+}
+
+impl<'a> ValueReader<'a> {
+    pub fn data_type(&self) -> &DataTypeNode {
+        self.data_type
+    }
+
+    pub fn read_bytes_fixed<const LEN: usize>(&mut self) -> Result<&'a [u8; LEN], ValueReadError> {
+        let (ret, rem) =
+            self.native_bytes
+                .split_first_chunk()
+                .ok_or(ValueReadError::InvalidLength {
+                    expected: LEN,
+                    actual: self.native_bytes.len(),
+                })?;
+
+        self.native_bytes = rem;
+
+        Ok(ret)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValueReadError {
+    #[error("expected {expected} bytes, got {actual}")]
+    InvalidLength { expected: usize, actual: usize },
+}
+
 pub trait Decode<'a>: Sized {
     fn compatible(data_type: &DataTypeNode) -> bool;
 
-    fn decode(
-        data_type: &DataTypeNode,
-        native_bytes: &'a [u8],
-    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>>;
+    fn decode(reader: &mut ValueReader<'a>)
+    -> Result<Self, Box<dyn Error + Send + Sync + 'static>>;
 
     fn decode_null(
         data_type: &DataTypeNode,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
         Err(format!("data type {data_type:?} cannot be NULL").into())
+    }
+
+    fn decode_array(data: ArrayData<'a>) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Err(format!("unexpected data type Array({})", data.elem_type).into())
     }
 }
 
@@ -24,12 +58,9 @@ impl<'a> Decode<'a> for u64 {
     }
 
     fn decode(
-        _data_type: &DataTypeNode,
-        native_bytes: &'a [u8],
+        reader: &mut ValueReader<'a>,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-        Ok(u64::from_le_bytes(native_bytes.try_into().map_err(
-            |_| format!("expected 8 bytes, got {}", native_bytes.len()),
-        )?))
+        Ok(u64::from_le_bytes(*reader.read_bytes_fixed()?))
     }
 }
 
@@ -39,11 +70,9 @@ impl<'a> Decode<'a> for &'a str {
     }
 
     fn decode(
-        data_type: &DataTypeNode,
-        native_bytes: &'a [u8],
+        reader: &mut ValueReader<'a>,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-        let s = <&[u8] as Decode>::decode(data_type, native_bytes)?;
-        Ok(str::from_utf8(s)?)
+        Ok(str::from_utf8(<&[u8] as Decode>::decode(reader)?)?)
     }
 }
 
@@ -53,10 +82,9 @@ impl<'a> Decode<'a> for String {
     }
 
     fn decode(
-        data_type: &DataTypeNode,
-        native_bytes: &'a [u8],
+        reader: &mut ValueReader<'a>,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-        Ok(<&str as Decode>::decode(data_type, native_bytes)?.into())
+        Ok(<&str as Decode>::decode(reader)?.into())
     }
 }
 
@@ -69,19 +97,19 @@ impl<'a> Decode<'a> for &'a [u8] {
     }
 
     fn decode(
-        data_type: &DataTypeNode,
-        mut native_bytes: &'a [u8],
+        reader: &mut ValueReader<'a>,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-        let len = if let DataTypeNode::FixedString(len) = *data_type {
+        let len = if let DataTypeNode::FixedString(len) = *reader.data_type {
             len
         } else {
             // Read `VarUInt` length prefix for `String`
-            let len = match parse_varuint(&mut native_bytes) {
+            let len = match parse_varuint(&mut reader.native_bytes) {
                 ControlFlow::Break(Ok(len)) => len,
                 ControlFlow::Break(Err(e)) => return Err(e.into()),
                 ControlFlow::Continue(_) => {
                     return Err(format!(
-                        "missing terminating byte in VarUInt encoding: {native_bytes:?}"
+                        "missing terminating byte in VarUInt encoding: {:?}",
+                        reader.native_bytes
                     )
                     .into());
                 }
@@ -91,15 +119,16 @@ impl<'a> Decode<'a> for &'a [u8] {
                 .map_err(|_| format!("length prefix of String out of range: {len}"))?
         };
 
-        if len != native_bytes.len() {
+        if len != reader.native_bytes.len() {
             return Err(format!(
-                "length of {data_type} does not match remaining length of buffer: {len} vs {}",
-                native_bytes.len()
+                "length of {:?} does not match remaining length of buffer: {len} vs {}",
+                reader.data_type,
+                reader.native_bytes.len()
             )
             .into());
         }
 
-        Ok(native_bytes)
+        Ok(reader.native_bytes)
     }
 }
 
@@ -113,14 +142,16 @@ impl<'a, T: Decode<'a>> Decode<'a> for Option<T> {
     }
 
     fn decode(
-        data_type: &DataTypeNode,
-        native_bytes: &'a [u8],
+        reader: &mut ValueReader<'a>,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-        let DataTypeNode::Nullable(inner_type) = data_type else {
-            return Err(format!("expected `Nullable(_)`, got {data_type:?}").into());
+        let DataTypeNode::Nullable(inner_type) = reader.data_type else {
+            return Err(format!("expected `Nullable(_)`, got {:?}", reader.data_type).into());
         };
 
-        Ok(Some(T::decode(inner_type, native_bytes)?))
+        Ok(Some(T::decode(&mut ValueReader {
+            data_type: inner_type,
+            native_bytes: reader.native_bytes,
+        })?))
     }
 
     fn decode_null(
@@ -131,20 +162,24 @@ impl<'a, T: Decode<'a>> Decode<'a> for Option<T> {
 }
 
 // FIXME: need to decide if `Vec<u8>` corresponds to `String` or `Array<UInt8>`
-// impl<'a, T: Decode<'a>> Decode<'a> for Vec<T> {
-//     fn compatible(data_type: &DataTypeNode) -> bool {
-//         if let DataTypeNode::Array(elem_type) = data_type {
-//             T::compatible(elem_type)
-//         } else {
-//             false
-//         }
-//     }
-//
-//     fn decode(data_type: &DataTypeNode, native_bytes: &'a [u8]) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-//         let DataTypeNode::Array(elem_type) = data_type else {
-//             return Err(format!("expected array type, got {data_type:?}").into());
-//         };
-//
-//
-//     }
-// }
+impl<'a, T: Decode<'a> + 'a> Decode<'a> for Vec<T> {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        if let DataTypeNode::Array(elem_type) = data_type {
+            T::compatible(elem_type)
+        } else {
+            false
+        }
+    }
+
+    fn decode(
+        reader: &mut ValueReader<'a>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Err(format!("expected array type, got {}", reader.data_type).into())
+    }
+
+    fn decode_array(data: ArrayData<'a>) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        data.into_reader::<T>()?
+            .collect::<Result<Vec<T>, crate::Error>>()
+            .map_err(Into::into)
+    }
+}

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -1,8 +1,6 @@
 use crate::native::array::ArrayData;
-use crate::native::reader::parse_varuint;
 use clickhouse_types::DataTypeNode;
 use std::error::Error;
-use std::ops::ControlFlow;
 
 pub struct ValueReader<'a> {
     pub(super) data_type: &'a DataTypeNode,
@@ -99,35 +97,6 @@ impl<'a> Decode<'a> for &'a [u8] {
     fn decode(
         reader: &mut ValueReader<'a>,
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
-        let len = if let DataTypeNode::FixedString(len) = *reader.data_type {
-            len
-        } else {
-            // Read `VarUInt` length prefix for `String`
-            let len = match parse_varuint(&mut reader.native_bytes) {
-                ControlFlow::Break(Ok(len)) => len,
-                ControlFlow::Break(Err(e)) => return Err(e.into()),
-                ControlFlow::Continue(_) => {
-                    return Err(format!(
-                        "missing terminating byte in VarUInt encoding: {:?}",
-                        reader.native_bytes
-                    )
-                    .into());
-                }
-            };
-
-            usize::try_from(len)
-                .map_err(|_| format!("length prefix of String out of range: {len}"))?
-        };
-
-        if len != reader.native_bytes.len() {
-            return Err(format!(
-                "length of {:?} does not match remaining length of buffer: {len} vs {}",
-                reader.data_type,
-                reader.native_bytes.len()
-            )
-            .into());
-        }
-
         Ok(reader.native_bytes)
     }
 }

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -10,6 +10,12 @@ pub trait Decode<'a>: Sized {
         data_type: &DataTypeNode,
         native_bytes: &'a [u8],
     ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>>;
+
+    fn decode_null(
+        data_type: &DataTypeNode,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Err(format!("data type {data_type:?} cannot be NULL").into())
+    }
 }
 
 impl<'a> Decode<'a> for u64 {
@@ -41,6 +47,19 @@ impl<'a> Decode<'a> for &'a str {
     }
 }
 
+impl<'a> Decode<'a> for String {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        <&str as Decode>::compatible(data_type)
+    }
+
+    fn decode(
+        data_type: &DataTypeNode,
+        native_bytes: &'a [u8],
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Ok(<&str as Decode>::decode(data_type, native_bytes)?.into())
+    }
+}
+
 impl<'a> Decode<'a> for &'a [u8] {
     fn compatible(data_type: &DataTypeNode) -> bool {
         matches!(
@@ -56,6 +75,7 @@ impl<'a> Decode<'a> for &'a [u8] {
         let len = if let DataTypeNode::FixedString(len) = *data_type {
             len
         } else {
+            // Read `VarUInt` length prefix for `String`
             let len = match parse_varuint(&mut native_bytes) {
                 ControlFlow::Break(Ok(len)) => len,
                 ControlFlow::Break(Err(e)) => return Err(e.into()),
@@ -82,3 +102,49 @@ impl<'a> Decode<'a> for &'a [u8] {
         Ok(native_bytes)
     }
 }
+
+impl<'a, T: Decode<'a>> Decode<'a> for Option<T> {
+    fn compatible(data_type: &DataTypeNode) -> bool {
+        if let DataTypeNode::Nullable(inner) = data_type {
+            T::compatible(inner)
+        } else {
+            false
+        }
+    }
+
+    fn decode(
+        data_type: &DataTypeNode,
+        native_bytes: &'a [u8],
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        let DataTypeNode::Nullable(inner_type) = data_type else {
+            return Err(format!("expected `Nullable(_)`, got {data_type:?}").into());
+        };
+
+        Ok(Some(T::decode(inner_type, native_bytes)?))
+    }
+
+    fn decode_null(
+        _data_type: &DataTypeNode,
+    ) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+        Ok(None)
+    }
+}
+
+// FIXME: need to decide if `Vec<u8>` corresponds to `String` or `Array<UInt8>`
+// impl<'a, T: Decode<'a>> Decode<'a> for Vec<T> {
+//     fn compatible(data_type: &DataTypeNode) -> bool {
+//         if let DataTypeNode::Array(elem_type) = data_type {
+//             T::compatible(elem_type)
+//         } else {
+//             false
+//         }
+//     }
+//
+//     fn decode(data_type: &DataTypeNode, native_bytes: &'a [u8]) -> Result<Self, Box<dyn Error + Send + Sync + 'static>> {
+//         let DataTypeNode::Array(elem_type) = data_type else {
+//             return Err(format!("expected array type, got {data_type:?}").into());
+//         };
+//
+//
+//     }
+// }

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -411,7 +411,7 @@ mod uuid {
             let hi_bytes = u64::from_le_bytes(*reader.read_bytes_fixed()?);
             let low_bytes = u64::from_le_bytes(*reader.read_bytes_fixed()?);
 
-            Ok(Uuid::from_u64_pair(hi_bytes.to_be(), low_bytes.to_be()))
+            Ok(Uuid::from_u64_pair(hi_bytes, low_bytes))
         }
     }
 }

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -355,7 +355,8 @@ impl Decode<'_> for Ipv4Addr {
         // https://clickhouse.com/docs/interfaces/specs/NativeFormat#ipv4-and-ipv6
         // IPv4 is byte-reversed, so little-endian
         let bytes_le = u32::from_le_bytes(*reader.read_bytes_fixed()?);
-        Ok(Ipv4Addr::from(bytes_le.to_be()))
+        // Performs the byte-swap internally
+        Ok(Ipv4Addr::from_bits(bytes_le))
     }
 }
 

--- a/src/native/decode.rs
+++ b/src/native/decode.rs
@@ -273,7 +273,11 @@ macro_rules! tuple_impl {
     () => {}
 }
 
-tuple_impl!(t1: T1, t2: T2, t3: T3);
+// `serde::Deserialize` is implemented for tuples up to 16 items
+tuple_impl!(
+    t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8, t9: T9,
+    t10: T10, t11: T11, t12: T12, t13: T13, t14: T14, t15: T15, t16: T16
+);
 
 impl<'a, K, V, S> Decode<'a> for HashMap<K, V, S>
 where

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1,13 +1,15 @@
 use crate::error::Error;
-use crate::native::decode::Decode;
 use crate::native::string::MaybeUtf8;
 use bytes::Bytes;
-use clickhouse_types::DataTypeNode;
 use clickhouse_types::data_types::{DecimalType, EnumType};
 use std::ops::Index;
 
-use crate::native::array::{ArrayData, ArrayReader};
 use hashbrown::HashMap;
+
+pub use array::{ArrayData, ArrayReader};
+pub use decode::Decode;
+
+pub use clickhouse_types::DataTypeNode;
 
 pub(crate) mod array;
 pub(crate) mod decode;

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -70,20 +70,35 @@ impl Index<usize> for Block {
 pub struct Column {
     name: MaybeUtf8,
     data_type: DataTypeNode,
-    data: Bytes,
     layout: Layout,
-    null_map: Option<Bytes>,
+    num_rows: usize,
 }
 
-enum Layout {
+struct Layout {
+    kind: LayoutKind,
+    nulls: Option<Bytes>,
+}
+
+enum LayoutKind {
     /// Fixed layout. Width of each cell depends only on [`DataTypeNode`].
-    Fixed { type_width: usize },
-    /// Offset of each item in the column data.
-    Offsets(Box<[usize]>),
+    Fixed { type_width: usize, data: Bytes },
+    /// Variable-length data (namely strings)
+    Variable {
+        /// Ending offset of each string in `data`.
+        ///
+        /// The offset of the first string is always `0` unless this is empty.
+        end_offsets: Box<[usize]>,
+        // Each `Bytes` instance is 4 `usizes` (32 bytes on 64-bit),
+        // so we save 24 bytes per string by linearizing the string data and storing offsets,
+        // assuming many small strings instead of fewer big ones, which also amortizes allocations
+        data: Bytes,
+    },
     /// Layout determined by `LowCardinality` metadata.
     LowCardinality(Arc<LowCardinality>),
+    /// Array data. Element data governed by `elem_layout`.
     Array {
-        cumulative_lengths: Box<[usize]>,
+        /// Ending index of each array in `elem_layout`.
+        end_indices: Box<[usize]>,
         elem_layout: Box<Layout>,
     },
 }
@@ -118,8 +133,7 @@ impl Column {
             iter: ArrayData {
                 elem_type: &self.data_type,
                 layout: &self.layout,
-                data: &self.data,
-                nulls: self.null_map.as_deref(),
+                indices: 0..self.num_rows,
             }
             .into_reader_unchecked(), // we already checked above with a more specific error
         })

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1,16 +1,16 @@
 use crate::error::Error;
-use crate::native::decode::Decode;
+use crate::native::decode::{Decode, ValueReader};
 use crate::native::string::MaybeUtf8;
 use bytes::Bytes;
 use clickhouse_types::DataTypeNode;
 use clickhouse_types::data_types::{DecimalType, EnumType};
-use std::marker::PhantomData;
 use std::ops::Index;
-use std::slice;
 use std::sync::Arc;
 
+use crate::native::array::{ArrayData, ArrayReader};
 use hashbrown::HashMap;
 
+pub(crate) mod array;
 pub(crate) mod decode;
 pub(crate) mod reader;
 pub(crate) mod string;
@@ -82,13 +82,9 @@ enum Layout {
     Offsets(Box<[usize]>),
     /// Layout determined by `LowCardinality` metadata.
     LowCardinality(Arc<LowCardinality>),
-    FixedArray {
-        type_width: usize,
-        lengths: Box<[usize]>,
-    },
     Array {
-        lengths: Box<[usize]>,
-        elem_layouts: Box<[Layout]>,
+        cumulative_lengths: Box<[usize]>,
+        elem_layout: Box<Layout>,
     },
 }
 
@@ -118,40 +114,21 @@ impl Column {
         }
 
         Ok(ColumnIter {
-            kind: match self.layout {
-                Layout::Fixed { type_width } => IterKind::Fixed(self.data.chunks_exact(type_width)),
-                Layout::Offsets(ref offsets) => IterKind::Offsets(offsets.iter()),
-                Layout::FixedArray {
-                    type_width,
-                    ref lengths,
-                } => IterKind::FixedArray {
-                    lengths: lengths.iter(),
-                    type_width,
-                },
-                Layout::Array { .. } => todo!("implement DynamicArray"),
-                Layout::LowCardinality(_) => todo!("implement LowCardinality"),
-            },
-            nulls: self.null_map.as_ref().map(|nulls| nulls.iter()),
             column: self,
-            ty: PhantomData,
+            iter: ArrayData {
+                elem_type: &self.data_type,
+                layout: &self.layout,
+                data: &self.data,
+                nulls: self.null_map.as_deref(),
+            }
+            .into_reader_unchecked(), // we already checked above with a more specific error
         })
     }
 }
 
-pub struct ColumnIter<'a, T: 'a> {
-    kind: IterKind<'a>,
-    nulls: Option<slice::Iter<'a, u8>>,
+pub struct ColumnIter<'a, T> {
     column: &'a Column,
-    ty: PhantomData<fn() -> T>,
-}
-
-enum IterKind<'a> {
-    Fixed(slice::ChunksExact<'a, u8>),
-    Offsets(slice::Iter<'a, usize>),
-    FixedArray {
-        lengths: slice::Iter<'a, usize>,
-        type_width: usize,
-    },
+    iter: ArrayReader<'a, T>,
 }
 
 impl<'a, T: 'a> Iterator for ColumnIter<'a, T>
@@ -161,45 +138,9 @@ where
     type Item = Result<T, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match &mut self.kind {
-            IterKind::Fixed(iter) => {
-                let native_bytes = iter.next()?;
-
-                if let Some(nulls) = &mut self.nulls {
-                    // not-null = 0x0
-                    if *nulls.next()? != 0 {
-                        return Some(T::decode_null(&self.column.data_type).map_err(Error::Other));
-                    }
-                }
-
-                Some(T::decode(&self.column.data_type, native_bytes).map_err(Error::Other))
-            }
-            IterKind::Offsets(iter) => {
-                let start = *iter.next()?;
-
-                if let Some(nulls) = &mut self.nulls {
-                    // not-null = 0x0
-                    if *nulls.next()? != 0 {
-                        return Some(T::decode_null(&self.column.data_type).map_err(Error::Other));
-                    }
-                }
-
-                let end = iter
-                    .as_slice()
-                    .first()
-                    .copied()
-                    .unwrap_or(self.column.data.len());
-
-                Some(
-                    T::decode(&self.column.data_type, &self.column.data[start..end])
-                        .map_err(Error::Other),
-                )
-            }
-        }
+        self.iter.next()
     }
 }
-
-pub struct ArrayColumnIter<'i, 'a: 'i, T: 'a> {}
 
 struct LowCardinality {}
 

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -175,6 +175,12 @@ where
     }
 }
 
+impl<'a, T> ColumnIter<'a, T> {
+    pub fn column(&self) -> &'a Column {
+        self.column
+    }
+}
+
 fn fixed_width(data_type: &DataTypeNode) -> Option<usize> {
     match data_type {
         DataTypeNode::Bool => Some(1),

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::native::decode::{Decode, ValueReader};
+use crate::native::decode::Decode;
 use crate::native::string::MaybeUtf8;
 use bytes::Bytes;
 use clickhouse_types::DataTypeNode;
@@ -81,7 +81,10 @@ struct Layout {
 
 enum LayoutKind {
     /// Fixed layout. Width of each cell depends only on [`DataTypeNode`].
-    Fixed { type_width: usize, data: Bytes },
+    Fixed {
+        type_width: usize,
+        data: Bytes,
+    },
     /// Variable-length data (namely strings)
     Variable {
         /// Ending offset of each string in `data`.
@@ -100,6 +103,13 @@ enum LayoutKind {
         /// Ending index of each array in `elem_layout`.
         end_indices: Box<[usize]>,
         elem_layout: Box<Layout>,
+    },
+    Tuple {
+        layouts: Box<[Layout]>,
+    },
+    Map {
+        key_val_layouts: Box<[Layout; 2]>,
+        end_indices: Box<[usize]>,
     },
 }
 

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -72,15 +72,24 @@ pub struct Column {
     data_type: DataTypeNode,
     data: Bytes,
     layout: Layout,
+    null_map: Option<Bytes>,
 }
 
 enum Layout {
     /// Fixed layout. Width of each cell depends only on [`DataTypeNode`].
     Fixed { type_width: usize },
-    /// Layout determined by `LowCardinality` metadata.
-    LowCardinality(Arc<LowCardinality>),
     /// Offset of each item in the column data.
     Offsets(Box<[usize]>),
+    /// Layout determined by `LowCardinality` metadata.
+    LowCardinality(Arc<LowCardinality>),
+    FixedArray {
+        type_width: usize,
+        lengths: Box<[usize]>,
+    },
+    Array {
+        lengths: Box<[usize]>,
+        elem_layouts: Box<[Layout]>,
+    },
 }
 
 impl Column {
@@ -112,8 +121,17 @@ impl Column {
             kind: match self.layout {
                 Layout::Fixed { type_width } => IterKind::Fixed(self.data.chunks_exact(type_width)),
                 Layout::Offsets(ref offsets) => IterKind::Offsets(offsets.iter()),
-                _ => todo!("unsupported layout kind"),
+                Layout::FixedArray {
+                    type_width,
+                    ref lengths,
+                } => IterKind::FixedArray {
+                    lengths: lengths.iter(),
+                    type_width,
+                },
+                Layout::Array { .. } => todo!("implement DynamicArray"),
+                Layout::LowCardinality(_) => todo!("implement LowCardinality"),
             },
+            nulls: self.null_map.as_ref().map(|nulls| nulls.iter()),
             column: self,
             ty: PhantomData,
         })
@@ -122,6 +140,7 @@ impl Column {
 
 pub struct ColumnIter<'a, T: 'a> {
     kind: IterKind<'a>,
+    nulls: Option<slice::Iter<'a, u8>>,
     column: &'a Column,
     ty: PhantomData<fn() -> T>,
 }
@@ -129,6 +148,10 @@ pub struct ColumnIter<'a, T: 'a> {
 enum IterKind<'a> {
     Fixed(slice::ChunksExact<'a, u8>),
     Offsets(slice::Iter<'a, usize>),
+    FixedArray {
+        lengths: slice::Iter<'a, usize>,
+        type_width: usize,
+    },
 }
 
 impl<'a, T: 'a> Iterator for ColumnIter<'a, T>
@@ -140,10 +163,27 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.kind {
             IterKind::Fixed(iter) => {
-                Some(T::decode(&self.column.data_type, iter.next()?).map_err(Error::Other))
+                let native_bytes = iter.next()?;
+
+                if let Some(nulls) = &mut self.nulls {
+                    // not-null = 0x0
+                    if *nulls.next()? != 0 {
+                        return Some(T::decode_null(&self.column.data_type).map_err(Error::Other));
+                    }
+                }
+
+                Some(T::decode(&self.column.data_type, native_bytes).map_err(Error::Other))
             }
             IterKind::Offsets(iter) => {
                 let start = *iter.next()?;
+
+                if let Some(nulls) = &mut self.nulls {
+                    // not-null = 0x0
+                    if *nulls.next()? != 0 {
+                        return Some(T::decode_null(&self.column.data_type).map_err(Error::Other));
+                    }
+                }
+
                 let end = iter
                     .as_slice()
                     .first()
@@ -158,6 +198,8 @@ where
         }
     }
 }
+
+pub struct ArrayColumnIter<'i, 'a: 'i, T: 'a> {}
 
 struct LowCardinality {}
 
@@ -197,9 +239,8 @@ fn fixed_width(data_type: &DataTypeNode) -> Option<usize> {
         DataTypeNode::Interval(_) => Some(8),
         DataTypeNode::IPv4 => Some(4),
         DataTypeNode::IPv6 => Some(8),
-        DataTypeNode::Nullable(inner) => fixed_width(inner)
-            // Nullable adds one byte per element
-            .and_then(|size| size.checked_add(1)),
+        // Nullable needs to be handled specially
+        DataTypeNode::Nullable(_) => None,
         // Type width determined by metadata that comes before column data.
         DataTypeNode::LowCardinality(_) => None,
         DataTypeNode::Array(_) => None,

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1,20 +1,28 @@
+use crate::error::Error;
+use crate::native::decode::Decode;
 use crate::native::string::MaybeUtf8;
 use bytes::Bytes;
 use clickhouse_types::DataTypeNode;
 use clickhouse_types::data_types::{DecimalType, EnumType};
-use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::ops::Index;
+use std::slice;
 use std::sync::Arc;
 
-mod reader;
-mod string;
+use hashbrown::HashMap;
+
+pub(crate) mod decode;
+pub(crate) mod reader;
+pub(crate) mod string;
 
 pub struct Block {
     column_names: HashMap<MaybeUtf8, usize>,
     columns: Vec<Column>,
+    num_rows: usize,
 }
 
 impl Block {
-    fn from_columns(columns: Vec<Column>) -> Self {
+    fn from_columns(columns: Vec<Column>, num_rows: usize) -> Self {
         Self {
             column_names: columns
                 .iter()
@@ -22,7 +30,40 @@ impl Block {
                 .map(|(i, column)| (column.name.clone(), i))
                 .collect(),
             columns,
+            num_rows,
         }
+    }
+
+    pub fn num_rows(&self) -> usize {
+        self.num_rows
+    }
+
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    pub fn column_by_name(&self, name: &str) -> Option<&Column> {
+        // Requires `hashbrown` for the `Equivalent` trait
+        let idx = *self.column_names.get(name)?;
+
+        Some(&self.columns[idx])
+    }
+}
+
+impl Index<&str> for Block {
+    type Output = Column;
+
+    fn index(&self, name: &str) -> &Self::Output {
+        self.column_by_name(name)
+            .unwrap_or_else(|| panic!("block does not contain a column with the name {name:?}"))
+    }
+}
+
+impl Index<usize> for Block {
+    type Output = Column;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.columns[index]
     }
 }
 
@@ -40,6 +81,82 @@ enum Layout {
     LowCardinality(Arc<LowCardinality>),
     /// Offset of each item in the column data.
     Offsets(Box<[usize]>),
+}
+
+impl Column {
+    /// # Panics
+    /// If the column name is not valid UTF-8.
+    ///
+    /// This is unlikely to happen if you have control over the column set returned by the query.
+    ///
+    /// Use [`Self::name_bytes()`] if panicking is unacceptable.
+    pub fn name(&self) -> &str {
+        self.name
+            .try_as_str()
+            .unwrap_or_else(|| panic!("column name {:?} is not valid UTF-8", self.name))
+    }
+
+    pub fn name_bytes(&self) -> &[u8] {
+        self.name.as_bytes()
+    }
+
+    pub fn iter<'a, T: Decode<'a>>(&'a self) -> Result<ColumnIter<'a, T>, Error> {
+        if !T::compatible(&self.data_type) {
+            return Err(Error::Custom(format!(
+                "incompatible data type {:?} of column {:?}",
+                self.data_type, self.name
+            )));
+        }
+
+        Ok(ColumnIter {
+            kind: match self.layout {
+                Layout::Fixed { type_width } => IterKind::Fixed(self.data.chunks_exact(type_width)),
+                Layout::Offsets(ref offsets) => IterKind::Offsets(offsets.iter()),
+                _ => todo!("unsupported layout kind"),
+            },
+            column: self,
+            ty: PhantomData,
+        })
+    }
+}
+
+pub struct ColumnIter<'a, T: 'a> {
+    kind: IterKind<'a>,
+    column: &'a Column,
+    ty: PhantomData<fn() -> T>,
+}
+
+enum IterKind<'a> {
+    Fixed(slice::ChunksExact<'a, u8>),
+    Offsets(slice::Iter<'a, usize>),
+}
+
+impl<'a, T: 'a> Iterator for ColumnIter<'a, T>
+where
+    T: Decode<'a>,
+{
+    type Item = Result<T, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.kind {
+            IterKind::Fixed(iter) => {
+                Some(T::decode(&self.column.data_type, iter.next()?).map_err(Error::Other))
+            }
+            IterKind::Offsets(iter) => {
+                let start = *iter.next()?;
+                let end = iter
+                    .as_slice()
+                    .first()
+                    .copied()
+                    .unwrap_or(self.column.data.len());
+
+                Some(
+                    T::decode(&self.column.data_type, &self.column.data[start..end])
+                        .map_err(Error::Other),
+                )
+            }
+        }
+    }
 }
 
 struct LowCardinality {}

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -131,7 +131,7 @@ impl Column {
     /// Use [`Self::name_bytes()`] if panicking is unacceptable.
     pub fn name(&self) -> &str {
         self.name
-            .try_as_str()
+            .as_str()
             .unwrap_or_else(|| panic!("column name {:?} is not valid UTF-8", self.name))
     }
 

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -71,12 +71,13 @@ pub struct Column {
     name: MaybeUtf8,
     data_type: DataTypeNode,
     layout: Layout,
-    num_rows: usize,
 }
 
 struct Layout {
     kind: LayoutKind,
     nulls: Option<Bytes>,
+    // Equivalent to `num_rows` for top-level values, but may be different for nested values
+    num_values: usize,
 }
 
 enum LayoutKind {
@@ -97,7 +98,7 @@ enum LayoutKind {
         data: Bytes,
     },
     /// Layout determined by `LowCardinality` metadata.
-    LowCardinality(Arc<LowCardinality>),
+    LowCardinality(LayoutLowCardinality),
     /// Array data. Element data governed by `elem_layout`.
     Array {
         /// Ending index of each array in `elem_layout`.
@@ -111,6 +112,14 @@ enum LayoutKind {
         key_val_layouts: Box<[Layout; 2]>,
         end_indices: Box<[usize]>,
     },
+}
+
+struct LayoutLowCardinality {
+    keys: Box<[usize]>,
+    global_dict: Option<Arc<Layout>>,
+    local_dict: Option<Box<Layout>>,
+    /// If `true`, `key = 1` should decode as `NULL` instead of the placeholder value given.
+    is_nullable: bool,
 }
 
 impl Column {
@@ -131,7 +140,7 @@ impl Column {
     }
 
     pub fn iter<'a, T: Decode<'a>>(&'a self) -> Result<ColumnIter<'a, T>, Error> {
-        if !T::compatible(&self.data_type) {
+        if !T::compatible(self.data_type.remove_low_cardinality()) {
             return Err(Error::Custom(format!(
                 "incompatible data type {:?} of column {:?}",
                 self.data_type, self.name
@@ -143,7 +152,7 @@ impl Column {
             iter: ArrayData {
                 elem_type: &self.data_type,
                 layout: &self.layout,
-                indices: 0..self.num_rows,
+                indices: 0..self.layout.num_values,
             }
             .into_reader_unchecked(), // we already checked above with a more specific error
         })
@@ -165,8 +174,6 @@ where
         self.iter.next()
     }
 }
-
-struct LowCardinality {}
 
 fn fixed_width(data_type: &DataTypeNode) -> Option<usize> {
     match data_type {

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1,0 +1,111 @@
+use crate::native::string::MaybeUtf8;
+use bytes::Bytes;
+use clickhouse_types::DataTypeNode;
+use clickhouse_types::data_types::{DecimalType, EnumType};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+mod reader;
+mod string;
+
+pub struct Block {
+    column_names: HashMap<MaybeUtf8, usize>,
+    columns: Vec<Column>,
+}
+
+impl Block {
+    fn from_columns(columns: Vec<Column>) -> Self {
+        Self {
+            column_names: columns
+                .iter()
+                .enumerate()
+                .map(|(i, column)| (column.name.clone(), i))
+                .collect(),
+            columns,
+        }
+    }
+}
+
+pub struct Column {
+    name: MaybeUtf8,
+    data_type: DataTypeNode,
+    data: Bytes,
+    layout: Layout,
+}
+
+enum Layout {
+    /// Fixed layout. Width of each cell depends only on [`DataTypeNode`].
+    Fixed { type_width: usize },
+    /// Layout determined by `LowCardinality` metadata.
+    LowCardinality(Arc<LowCardinality>),
+    /// Offset of each item in the column data.
+    Offsets(Box<[usize]>),
+}
+
+struct LowCardinality {}
+
+fn fixed_width(data_type: &DataTypeNode) -> Option<usize> {
+    match data_type {
+        DataTypeNode::Bool => Some(1),
+        DataTypeNode::UInt8 => Some(1),
+        DataTypeNode::UInt16 => Some(2),
+        DataTypeNode::UInt32 => Some(4),
+        DataTypeNode::UInt64 => Some(8),
+        DataTypeNode::UInt128 => Some(16),
+        DataTypeNode::UInt256 => Some(32),
+        DataTypeNode::Int8 => Some(1),
+        DataTypeNode::Int16 => Some(2),
+        DataTypeNode::Int32 => Some(4),
+        DataTypeNode::Int64 => Some(8),
+        DataTypeNode::Int128 => Some(16),
+        DataTypeNode::Int256 => Some(32),
+        DataTypeNode::Float32 => Some(4),
+        DataTypeNode::Float64 => Some(8),
+        DataTypeNode::BFloat16 => Some(2),
+        DataTypeNode::Decimal(_, _, type_) => match type_ {
+            DecimalType::Decimal32 => Some(4),
+            DecimalType::Decimal64 => Some(8),
+            DecimalType::Decimal128 => Some(16),
+            DecimalType::Decimal256 => Some(32),
+        },
+        DataTypeNode::String => None,
+        DataTypeNode::FixedString(len) => Some(*len),
+        DataTypeNode::UUID => Some(16),
+        DataTypeNode::Date => Some(2),
+        DataTypeNode::Date32 => Some(4),
+        DataTypeNode::DateTime(_) => Some(4),
+        DataTypeNode::DateTime64(_, _) => Some(8),
+        DataTypeNode::Time => Some(4),
+        DataTypeNode::Time64(_) => Some(8),
+        DataTypeNode::Interval(_) => Some(8),
+        DataTypeNode::IPv4 => Some(4),
+        DataTypeNode::IPv6 => Some(8),
+        DataTypeNode::Nullable(inner) => fixed_width(inner)
+            // Nullable adds one byte per element
+            .and_then(|size| size.checked_add(1)),
+        // Type width determined by metadata that comes before column data.
+        DataTypeNode::LowCardinality(_) => None,
+        DataTypeNode::Array(_) => None,
+        DataTypeNode::Tuple(types) => types.iter().try_fold(0usize, |total, inner| {
+            total.checked_add(fixed_width(inner)?)
+        }),
+        DataTypeNode::Enum(type_, _) => match type_ {
+            EnumType::Enum8 => Some(1),
+            EnumType::Enum16 => Some(2),
+        },
+        DataTypeNode::Map(_) => None,
+        DataTypeNode::AggregateFunction(_, _) => None,
+        DataTypeNode::SimpleAggregateFunction(_, inner) => fixed_width(inner),
+        DataTypeNode::Variant(_) => None,
+        DataTypeNode::Dynamic => None,
+        DataTypeNode::JSON => None,
+        DataTypeNode::JsonWithHint(_) => None,
+        DataTypeNode::Point => Some(16), // Tuple(Float64, Float64)
+        DataTypeNode::Ring => None,
+        DataTypeNode::LineString => None,
+        DataTypeNode::MultiLineString => None,
+        DataTypeNode::Polygon => None,
+        DataTypeNode::MultiPolygon => None,
+        _ => None,
+    }
+}

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -173,6 +173,10 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<'a, T> ColumnIter<'a, T> {

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -216,7 +216,7 @@ fn fixed_width(data_type: &DataTypeNode) -> Option<usize> {
         DataTypeNode::Time64(_) => Some(8),
         DataTypeNode::Interval(_) => Some(8),
         DataTypeNode::IPv4 => Some(4),
-        DataTypeNode::IPv6 => Some(8),
+        DataTypeNode::IPv6 => Some(16),
         // Nullable needs to be handled specially
         DataTypeNode::Nullable(_) => None,
         // Type width determined by metadata that comes before column data.

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -5,7 +5,6 @@ use bytes::Bytes;
 use clickhouse_types::DataTypeNode;
 use clickhouse_types::data_types::{DecimalType, EnumType};
 use std::ops::Index;
-use std::sync::Arc;
 
 use crate::native::array::{ArrayData, ArrayReader};
 use hashbrown::HashMap;
@@ -116,9 +115,8 @@ enum LayoutKind {
 
 struct LayoutLowCardinality {
     keys: Box<[usize]>,
-    global_dict: Option<Arc<Layout>>,
-    local_dict: Option<Box<Layout>>,
-    /// If `true`, `key = 1` should decode as `NULL` instead of the placeholder value given.
+    dict: Box<Layout>,
+    /// If `true`, `key = 0` should decode as `NULL` instead of the placeholder value given.
     is_nullable: bool,
 }
 
@@ -185,7 +183,7 @@ impl<'a, T> ColumnIter<'a, T> {
     }
 }
 
-fn fixed_width(data_type: &DataTypeNode) -> Option<usize> {
+fn type_fixed_width(data_type: &DataTypeNode) -> Option<usize> {
     match data_type {
         DataTypeNode::Bool => Some(1),
         DataTypeNode::UInt8 => Some(1),
@@ -227,7 +225,7 @@ fn fixed_width(data_type: &DataTypeNode) -> Option<usize> {
         DataTypeNode::LowCardinality(_) => None,
         DataTypeNode::Array(_) => None,
         DataTypeNode::Tuple(types) => types.iter().try_fold(0usize, |total, inner| {
-            total.checked_add(fixed_width(inner)?)
+            total.checked_add(type_fixed_width(inner)?)
         }),
         DataTypeNode::Enum(type_, _) => match type_ {
             EnumType::Enum8 => Some(1),
@@ -235,7 +233,7 @@ fn fixed_width(data_type: &DataTypeNode) -> Option<usize> {
         },
         DataTypeNode::Map(_) => None,
         DataTypeNode::AggregateFunction(_, _) => None,
-        DataTypeNode::SimpleAggregateFunction(_, inner) => fixed_width(inner),
+        DataTypeNode::SimpleAggregateFunction(_, inner) => type_fixed_width(inner),
         DataTypeNode::Variant(_) => None,
         DataTypeNode::Dynamic => None,
         DataTypeNode::JSON => None,

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -8,6 +8,7 @@ use hashbrown::HashMap;
 
 pub use array::{ArrayData, ArrayReader};
 pub use decode::Decode;
+pub use reader::BlockReadError;
 
 pub use clickhouse_types::DataTypeNode;
 
@@ -141,7 +142,7 @@ impl Column {
 
     pub fn iter<'a, T: Decode<'a>>(&'a self) -> Result<ColumnIter<'a, T>, Error> {
         if !T::compatible(self.data_type.remove_low_cardinality()) {
-            return Err(Error::Custom(format!(
+            return Err(Error::SchemaMismatch(format!(
                 "incompatible data type {:?} of column {:?}",
                 self.data_type, self.name
             )));

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -480,14 +480,7 @@ pub(super) struct ParseVarUInt {
 }
 
 impl ParseVarUInt {
-    pub fn parse_full(buf: impl Buf) -> Result<u64, Error> {
-        Self::default()
-            .feed(buf)?
-            .break_value()
-            .ok_or(Error::NotEnoughData)
-    }
-
-    pub fn feed(&mut self, mut buf: impl Buf) -> Result<ControlFlow<u64>, Error> {
+    fn feed(&mut self, mut buf: impl Buf) -> Result<ControlFlow<u64>, Error> {
         const MAX_LEN: usize = 10;
 
         for _ in 0..MAX_LEN {

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -83,7 +83,7 @@ impl BlockReader {
         let name = self.inner.read_string().await?;
         let data_type = self.inner.read_string().await?;
 
-        let data_type = data_type.try_as_str().ok_or_else(|| {
+        let data_type = data_type.as_str().ok_or_else(|| {
             Error::Custom(format!(
                 "invalid data type {data_type:?} of column {name:?}"
             ))

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -445,6 +445,10 @@ impl ReaderInner {
     }
 
     async fn read_bytes(&mut self, len: usize) -> Result<Bytes, Error> {
+        if len == 0 {
+            return Ok(Bytes::new());
+        }
+
         self.read_chunk().await?;
 
         if self.last_chunk.len() >= len {

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -151,7 +151,7 @@ impl BlockReader {
                 let mut total_len = 0;
 
                 for _ in 0..num_rows {
-                    // Note: cumulative length
+                    // Note: cumulative length, last value is total number of elements
                     let length = u64::from_le_bytes(self.read_bytes(8).await?.try_into().unwrap());
 
                     let length = usize::try_from(length).map_err(|_| {
@@ -175,9 +175,9 @@ impl BlockReader {
 
                     return Ok((
                         self.buffer.split().freeze(),
-                        Layout::FixedArray {
-                            type_width,
-                            lengths: lengths.into(),
+                        Layout::Array {
+                            elem_layout: Box::new(Layout::Fixed { type_width }),
+                            cumulative_lengths: lengths.into(),
                         },
                     ));
                 }

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -125,18 +125,7 @@ impl BlockReader {
                 })
             }
             DataTypeNode::Array(elem_type) => {
-                let mut end_indices = Vec::with_capacity(num_rows);
-
-                for _ in 0..num_rows {
-                    // Note: cumulative length, last value is total number of elements
-                    let length = u64::from_le_bytes(self.read_bytes_fixed().await?);
-
-                    let length = usize::try_from(length).map_err(|_| {
-                        Error::Custom(format!("array length out of range: {length}"))
-                    })?;
-
-                    end_indices.push(length);
-                }
+                let end_indices = self.read_array_indices(num_rows).await?;
 
                 let total_len = end_indices.last().copied().unwrap_or(0);
 
@@ -145,8 +134,42 @@ impl BlockReader {
 
                 Ok(Layout {
                     kind: LayoutKind::Array {
-                        end_indices: end_indices.into(),
+                        end_indices,
                         elem_layout: Box::new(elem_layout),
+                    },
+                    nulls,
+                })
+            }
+            DataTypeNode::Tuple(types) => {
+                let mut layouts = Vec::with_capacity(types.len());
+
+                for ty in types {
+                    layouts.push(Box::pin(self.read_type_data(ty, num_rows)).await?);
+                }
+
+                Ok(Layout {
+                    kind: LayoutKind::Tuple {
+                        layouts: layouts.into(),
+                    },
+                    nulls,
+                })
+            }
+            DataTypeNode::Map([key_ty, val_ty]) => {
+                // Maps are just `Array(Tuple(K, V))` but the way this code is structured,
+                // it's easier to create a specialized routine to read them
+                let end_indices = self.read_array_indices(num_rows).await?;
+
+                let total_len = end_indices.last().copied().unwrap_or(0);
+
+                // Keys semantically cannot be `LowCardinality` or `Nullable`
+                // but that doesn't really affect decoding
+                let key_layout = Box::pin(self.read_type_data(key_ty, total_len)).await?;
+                let value_layout = Box::pin(self.read_type_data(val_ty, total_len)).await?;
+
+                Ok(Layout {
+                    kind: LayoutKind::Map {
+                        key_val_layouts: Box::new([key_layout, value_layout]),
+                        end_indices,
                     },
                     nulls,
                 })
@@ -176,6 +199,22 @@ impl BlockReader {
 
             self.read_chunk().await?;
         }
+    }
+
+    async fn read_array_indices(&mut self, num_rows: usize) -> Result<Box<[usize]>, Error> {
+        let mut end_indices = Vec::with_capacity(num_rows);
+
+        for _ in 0..num_rows {
+            // Note: cumulative length, last value is total number of elements
+            let length = u64::from_le_bytes(self.read_bytes_fixed().await?);
+
+            let length = usize::try_from(length)
+                .map_err(|_| Error::Custom(format!("array length out of range: {length}")))?;
+
+            end_indices.push(length);
+        }
+
+        Ok(end_indices.into())
     }
 
     async fn read_bytes(&mut self, len: usize) -> Result<Bytes, Error> {

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -1,30 +1,60 @@
 use crate::error::Error;
 use crate::native::string::MaybeUtf8;
-use crate::native::{Block, Column, Layout, LayoutKind, fixed_width};
+use crate::native::{Block, Column, Layout, LayoutKind, LayoutLowCardinality, fixed_width};
 use crate::response::Chunks;
 use bytes::{Buf, Bytes, BytesMut};
 use clickhouse_types::DataTypeNode;
 use futures_util::StreamExt;
+use hashbrown::{HashMap, hash_map};
 use std::cmp;
 use std::ops::ControlFlow;
+use std::sync::Arc;
 
 pub(crate) struct BlockReader {
+    inner: ReaderInner,
+    lc_state: LcState,
+}
+
+struct ReaderInner {
     chunks: Chunks,
     last_chunk: Bytes,
+}
+
+/// `LowCardinality` decode state for the current stream.
+struct LcState {
+    by_column: HashMap<MaybeUtf8, ColumnLcState>,
+}
+
+struct ColumnLcState {
+    global_dict: Option<Arc<Layout>>,
+}
+
+#[repr(u64)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+enum LcKeyType {
+    UInt8 = 0,
+    UInt16,
+    UInt32,
+    UInt64,
 }
 
 impl BlockReader {
     pub(crate) fn new(chunks: Chunks) -> Self {
         BlockReader {
-            chunks,
-            last_chunk: Bytes::new(),
+            inner: ReaderInner {
+                chunks,
+                last_chunk: Bytes::new(),
+            },
+            lc_state: LcState {
+                by_column: HashMap::new(),
+            },
         }
     }
 
     /// **NOT** cancel-safe. Intended to be wrapped in an async task for cancel-safety.
     pub(crate) async fn read_block(&mut self) -> Result<Option<Block>, Error> {
-        let num_columns = self.read_varuint().await?;
-        let num_rows = self.read_varuint().await?;
+        let num_columns = self.inner.read_varuint().await?;
+        let num_rows = self.inner.read_varuint().await?;
 
         let num_rows = usize::try_from(num_rows).map_err(|_| {
             Error::Custom(format!(
@@ -38,16 +68,18 @@ impl BlockReader {
 
         let mut columns = Vec::new();
 
-        for _ in 0..num_columns {
-            columns.push(self.read_column(num_rows).await?);
+        for col in 0..num_columns {
+            columns.push(self.read_column(num_rows).await.inspect_err(|e| {
+                tracing::debug!(col, "error reading column: {e:?}");
+            })?);
         }
 
         Ok(Some(Block::from_columns(columns, num_rows)))
     }
 
     async fn read_column(&mut self, num_rows: usize) -> Result<Column, Error> {
-        let name = self.read_string().await?;
-        let data_type = self.read_string().await?;
+        let name = self.inner.read_string().await?;
+        let data_type = self.inner.read_string().await?;
 
         let data_type = data_type.try_as_str().ok_or_else(|| {
             Error::Custom(format!(
@@ -61,41 +93,42 @@ impl BlockReader {
             ))
         })?;
 
-        let layout = self.read_type_data(&data_type, num_rows).await?;
+        let layout = self.read_type_data(&name, &data_type, num_rows).await?;
 
         Ok(Column {
             name,
             data_type,
             layout,
-            num_rows,
         })
     }
 
     async fn read_type_data(
         &mut self,
+        column_name: &MaybeUtf8,
         data_type: &DataTypeNode,
-        num_rows: usize,
+        num_values: usize,
     ) -> Result<Layout, Error> {
         let (data_type, nulls) = if let DataTypeNode::Nullable(inner) = data_type {
             // Read off the null bitmap
-            (&**inner, Some(self.read_bytes(num_rows).await?))
+            (&**inner, Some(self.inner.read_bytes(num_values).await?))
         } else {
             (data_type, None)
         };
 
         if let Some(type_width) = fixed_width(data_type) {
-            let total_bytes = type_width.checked_mul(num_rows).ok_or_else(|| {
+            let total_bytes = type_width.checked_mul(num_values).ok_or_else(|| {
                 Error::Custom(format!(
-                    "data size is too large: {num_rows} rows X {type_width} bytes"
+                    "data size of column {column_name:?} is too large: {num_values} rows X {type_width} bytes"
                 ))
             })?;
 
             return Ok(Layout {
                 kind: LayoutKind::Fixed {
                     type_width,
-                    data: self.read_bytes(total_bytes).await?,
+                    data: self.inner.read_bytes(total_bytes).await?,
                 },
                 nulls,
+                num_values,
             });
         }
 
@@ -103,16 +136,16 @@ impl BlockReader {
             DataTypeNode::String => {
                 // Assume default growth strategy is fine
                 let mut data = BytesMut::new();
-                let mut end_offsets = Vec::with_capacity(num_rows);
+                let mut end_offsets = Vec::with_capacity(num_values);
 
-                for row in 0..num_rows {
-                    let len = self.read_varuint().await?;
+                for row in 0..num_values {
+                    let len = self.inner.read_varuint().await?;
 
                     let len = usize::try_from(len).map_err(|_| {
                         Error::Custom(format!("string #{row} length {len} is out of range"))
                     })?;
 
-                    self.read_bytes_into(len, &mut data).await?;
+                    self.inner.read_bytes_into(len, &mut data).await?;
                     end_offsets.push(data.len());
                 }
 
@@ -122,15 +155,17 @@ impl BlockReader {
                         end_offsets: end_offsets.into(),
                     },
                     nulls,
+                    num_values,
                 })
             }
             DataTypeNode::Array(elem_type) => {
-                let end_indices = self.read_array_indices(num_rows).await?;
+                let end_indices = self.inner.read_array_indices(num_values).await?;
 
                 let total_len = end_indices.last().copied().unwrap_or(0);
 
                 // Recursive `async fn` currently requires boxing
-                let elem_layout = Box::pin(self.read_type_data(elem_type, total_len)).await?;
+                let elem_layout =
+                    Box::pin(self.read_type_data(column_name, elem_type, total_len)).await?;
 
                 Ok(Layout {
                     kind: LayoutKind::Array {
@@ -138,13 +173,14 @@ impl BlockReader {
                         elem_layout: Box::new(elem_layout),
                     },
                     nulls,
+                    num_values,
                 })
             }
             DataTypeNode::Tuple(types) => {
                 let mut layouts = Vec::with_capacity(types.len());
 
                 for ty in types {
-                    layouts.push(Box::pin(self.read_type_data(ty, num_rows)).await?);
+                    layouts.push(Box::pin(self.read_type_data(column_name, ty, num_values)).await?);
                 }
 
                 Ok(Layout {
@@ -152,19 +188,22 @@ impl BlockReader {
                         layouts: layouts.into(),
                     },
                     nulls,
+                    num_values,
                 })
             }
             DataTypeNode::Map([key_ty, val_ty]) => {
                 // Maps are just `Array(Tuple(K, V))` but the way this code is structured,
                 // it's easier to create a specialized routine to read them
-                let end_indices = self.read_array_indices(num_rows).await?;
+                let end_indices = self.inner.read_array_indices(num_values).await?;
 
                 let total_len = end_indices.last().copied().unwrap_or(0);
 
                 // Keys semantically cannot be `LowCardinality` or `Nullable`
                 // but that doesn't really affect decoding
-                let key_layout = Box::pin(self.read_type_data(key_ty, total_len)).await?;
-                let value_layout = Box::pin(self.read_type_data(val_ty, total_len)).await?;
+                let key_layout =
+                    Box::pin(self.read_type_data(column_name, key_ty, total_len)).await?;
+                let value_layout =
+                    Box::pin(self.read_type_data(column_name, val_ty, total_len)).await?;
 
                 Ok(Layout {
                     kind: LayoutKind::Map {
@@ -172,6 +211,19 @@ impl BlockReader {
                         end_indices,
                     },
                     nulls,
+                    num_values,
+                })
+            }
+            DataTypeNode::LowCardinality(inner_type) => {
+                Ok(Layout {
+                    kind: LayoutKind::LowCardinality(
+                        self.read_low_cardinality(column_name, inner_type, num_values)
+                            .await?,
+                    ),
+                    // Can be `Some` if the type is `Nullable(LowCardinality(...))`
+                    // even though `LowCardinality(Nullable(...))` is more efficient
+                    nulls,
+                    num_values,
                 })
             }
             _ => Err(Error::Custom(format!(
@@ -180,6 +232,103 @@ impl BlockReader {
         }
     }
 
+    async fn read_low_cardinality(
+        &mut self,
+        column_name: &MaybeUtf8,
+        inner_type: &DataTypeNode,
+        num_rows: usize,
+    ) -> Result<LayoutLowCardinality, Error> {
+        const HAS_ADDITIONAL_KEYS_BIT: u64 = 0x200;
+        const NEEDS_UPDATE_DICTIONARY_BIT: u64 = 0x400;
+        const NEED_GLOBAL_DICTIONARY_BIT: u64 = 0x800;
+
+        if num_rows == 0 {
+            todo!("empty result contains no prefix");
+        }
+
+        if let hash_map::EntryRef::Vacant(vacant) = self.lc_state.by_column.entry_ref(column_name) {
+            // We haven't seen the state prefix for this query yet
+            let prefix = self.inner.read_int64().await?;
+
+            if prefix != 1 {
+                // sharedDictionariesWithAdditionalKeys
+                return Err(Error::Custom(format!(
+                    "unexpected/unsupported serialization version of type \
+                             LowCardinality({inner_type}) of column {column_name:?}: \
+                             expected 1, got {prefix}"
+                )));
+            }
+
+            vacant.insert(ColumnLcState { global_dict: None });
+        };
+
+        let metadata = self.inner.read_uint64().await?;
+
+        let key_type = LcKeyType::try_from_metadata(metadata)?;
+
+        let has_additional_keys = metadata & HAS_ADDITIONAL_KEYS_BIT != 0;
+        let needs_update_dictionary = metadata & NEEDS_UPDATE_DICTIONARY_BIT != 0;
+        let need_global_dictionary = metadata & NEED_GLOBAL_DICTIONARY_BIT != 0;
+
+        let dict_len = self.inner.read_uint64().await?;
+        let dict_len = usize::try_from(dict_len)
+            .map_err(|_| Error::Custom(format!("column {column_name:?} type LowCardinality({inner_type}) dictionary size too large: {dict_len}")))?;
+
+        // `LowCardinality(Nullable)` doesn't emit a null map, instead `dict[1]` is the null value
+        let (non_nullable, is_nullable) = if let DataTypeNode::Nullable(inner) = inner_type {
+            (&**inner, true)
+        } else {
+            (inner_type, false)
+        };
+
+        // called from `self.read_type_data()` so we have to box
+        let dict = Box::pin(self.read_type_data(column_name, non_nullable, dict_len)).await?;
+
+        let keys_len = self.inner.read_uint64().await?;
+        let keys_len = usize::try_from(keys_len)
+            .map_err(|_| Error::Custom(format!("column {column_name:?} type LowCardinality({inner_type}) keys count too large: {keys_len}")))?;
+
+        if keys_len != num_rows {
+            return Err(Error::Custom(format!(
+                "column {column_name:?} type LowCardinality({inner_type}) keys count does not match number of rows in block: {keys_len} vs {num_rows}; this likely means a bug or corrupted data"
+            )));
+        }
+
+        let keys = self.inner.read_lc_keys(key_type, num_rows).await?;
+
+        // Cannot be borrowed across other calls to `self` so we have to do a second lookup;
+        // we could amortize by using `IndexMap` but two lookups per column is unlikely to be an issue
+        let state = self
+            .lc_state
+            .by_column
+            .get_mut(column_name)
+            .unwrap_or_else(|| panic!("BUG: `lc_state` should have been initialized"));
+
+        let (global_dict, local_dict) = if need_global_dictionary {
+            let global_dict = state.global_dict
+                .clone()
+                .ok_or_else(|| Error::Custom(format!("column {column_name:?} type LowCardinality({inner_type}) set NEEDS_GLOBAL_DICTIONARY_BIT for a block but no global dictionary was read")))?;
+
+            (
+                Some(global_dict),
+                has_additional_keys.then(|| Box::new(dict)),
+            )
+        } else if needs_update_dictionary {
+            (Some(state.global_dict.insert(Arc::new(dict)).clone()), None)
+        } else {
+            (None, Some(Box::new(dict)))
+        };
+
+        Ok(LayoutLowCardinality {
+            global_dict,
+            local_dict,
+            keys,
+            is_nullable,
+        })
+    }
+}
+
+impl ReaderInner {
     async fn read_string(&mut self) -> Result<MaybeUtf8, Error> {
         let len = self.read_varuint().await?;
 
@@ -206,7 +355,7 @@ impl BlockReader {
 
         for _ in 0..num_rows {
             // Note: cumulative length, last value is total number of elements
-            let length = u64::from_le_bytes(self.read_bytes_fixed().await?);
+            let length = self.read_uint64().await?;
 
             let length = usize::try_from(length)
                 .map_err(|_| Error::Custom(format!("array length out of range: {length}")))?;
@@ -215,6 +364,32 @@ impl BlockReader {
         }
 
         Ok(end_indices.into())
+    }
+
+    async fn read_lc_keys(
+        &mut self,
+        key_type: LcKeyType,
+        num_rows: usize,
+    ) -> Result<Box<[usize]>, Error> {
+        let mut keys = Vec::with_capacity(num_rows);
+
+        for i in 0..num_rows {
+            let mut buf = [0u8; LcKeyType::MAX_BYTE_WIDTH];
+
+            self.fill_buf(&mut buf[..key_type.byte_width()]).await?;
+
+            let key = u64::from_le_bytes(buf);
+
+            let key = usize::try_from(key).map_err(|_| {
+                Error::Custom(format!(
+                    "LowCardinality dictionary key out of range at index {i}: {key}"
+                ))
+            })?;
+
+            keys.push(key);
+        }
+
+        Ok(keys.into())
     }
 
     async fn read_bytes(&mut self, len: usize) -> Result<Bytes, Error> {
@@ -230,38 +405,54 @@ impl BlockReader {
         Ok(buf.freeze())
     }
 
-    async fn read_bytes_into(
-        &mut self,
-        mut read_len: usize,
-        buf: &mut BytesMut,
-    ) -> Result<(), Error> {
-        while read_len > 0 {
+    async fn read_bytes_into(&mut self, mut amt: usize, buf: &mut BytesMut) -> Result<(), Error> {
+        while amt > 0 {
             self.read_chunk().await?;
 
-            let data = self
-                .last_chunk
-                .split_to(cmp::min(read_len, self.last_chunk.len()));
-            buf.extend_from_slice(&data);
-            read_len -= data.len();
+            let read_len = cmp::min(self.last_chunk.len(), amt);
+
+            buf.extend_from_slice(&self.last_chunk[..read_len]);
+
+            self.consume(read_len);
+
+            amt -= read_len;
         }
 
         Ok(())
     }
 
     async fn read_bytes_fixed<const LEN: usize>(&mut self) -> Result<[u8; LEN], Error> {
-        let mut read_len = 0;
         let mut buf = [0u8; LEN];
 
-        while read_len < LEN {
-            self.read_chunk().await?;
-
-            let amt = cmp::min(LEN - read_len, self.last_chunk.len());
-            buf[read_len..].copy_from_slice(&self.last_chunk[..amt]);
-            read_len += amt;
-            self.last_chunk.advance(amt);
-        }
+        self.fill_buf(&mut buf).await?;
 
         Ok(buf)
+    }
+
+    async fn fill_buf(&mut self, mut buf: &mut [u8]) -> Result<(), Error> {
+        while !buf.is_empty() {
+            self.read_chunk().await?;
+
+            let read_len = cmp::min(buf.len(), self.last_chunk.len());
+
+            let dst = buf
+                .split_off_mut(..read_len)
+                .expect("BUG: we just validated `read_len` is in bounds");
+
+            dst.copy_from_slice(&self.last_chunk[..read_len]);
+
+            self.consume(read_len);
+        }
+
+        Ok(())
+    }
+
+    async fn read_uint64(&mut self) -> Result<u64, Error> {
+        Ok(u64::from_le_bytes(self.read_bytes_fixed().await?))
+    }
+
+    async fn read_int64(&mut self) -> Result<i64, Error> {
+        Ok(i64::from_le_bytes(self.read_bytes_fixed().await?))
     }
 
     async fn read_chunk(&mut self) -> Result<(), Error> {
@@ -270,6 +461,16 @@ impl BlockReader {
         }
 
         Ok(())
+    }
+
+    fn consume(&mut self, len: usize) {
+        self.last_chunk.advance(len);
+
+        // `Bytes::advance()` doesn't decrement the refcount when it's empty,
+        // preventing the buffer from being reused
+        if self.last_chunk.is_empty() {
+            self.last_chunk = Bytes::new();
+        }
     }
 }
 
@@ -312,5 +513,34 @@ impl ParseVarUInt {
             "terminating byte missing in VarUInt encoding: {:016x}",
             self.accumulator,
         )))
+    }
+}
+
+impl LcKeyType {
+    const MASK: u64 = 0xFF; // Low 8 bits
+
+    const MAX_BYTE_WIDTH: usize = Self::UInt64.byte_width();
+
+    fn try_from_metadata(metadata: u64) -> Result<Self, Error> {
+        Ok(match metadata & Self::MASK {
+            0 => Self::UInt8,
+            1 => Self::UInt16,
+            2 => Self::UInt32,
+            3 => Self::UInt64,
+            unknown => {
+                return Err(Error::Custom(format!(
+                    "unknown LowCardinality key type: {unknown}"
+                )));
+            }
+        })
+    }
+
+    const fn byte_width(&self) -> usize {
+        match self {
+            LcKeyType::UInt8 => 1,
+            LcKeyType::UInt16 => 2,
+            LcKeyType::UInt32 => 4,
+            LcKeyType::UInt64 => 8,
+        }
     }
 }

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -1,41 +1,28 @@
 use crate::error::Error;
 use crate::native::string::MaybeUtf8;
-use crate::native::{Block, Column, Layout, fixed_width};
-use crate::response::{Chunk, Chunks};
-use bytes::{Bytes, BytesMut};
+use crate::native::{Block, Column, Layout, LayoutKind, fixed_width};
+use crate::response::Chunks;
+use bytes::{Buf, Bytes, BytesMut};
 use clickhouse_types::DataTypeNode;
 use futures_util::StreamExt;
+use std::cmp;
 use std::ops::ControlFlow;
 
 pub(crate) struct BlockReader {
     chunks: Chunks,
-    buffer: Buffer,
-}
-
-struct Buffer {
-    bytes: BytesMut,
-    marker: usize,
+    last_chunk: Bytes,
 }
 
 impl BlockReader {
     pub(crate) fn new(chunks: Chunks) -> Self {
         BlockReader {
             chunks,
-            buffer: Buffer {
-                bytes: BytesMut::new(),
-                marker: 0,
-            },
+            last_chunk: Bytes::new(),
         }
     }
 
     /// **NOT** cancel-safe. Intended to be wrapped in an async task for cancel-safety.
     pub(crate) async fn read_block(&mut self) -> Result<Option<Block>, Error> {
-        if let Some(chunk) = self.chunks.next().await.transpose()? {
-            self.buffer.push(chunk);
-        } else if self.buffer.bytes.is_empty() {
-            return Ok(None);
-        };
-
         let num_columns = self.read_varuint().await?;
         let num_rows = self.read_varuint().await?;
 
@@ -48,9 +35,6 @@ impl BlockReader {
         if num_columns == 0 {
             return Ok(None);
         }
-
-        // Remove the block header from the buffer
-        self.buffer.split();
 
         let mut columns = Vec::new();
 
@@ -77,115 +61,98 @@ impl BlockReader {
             ))
         })?;
 
-        // Split the column header from the data
-        self.buffer.split();
+        let layout = self.read_type_data(&data_type, num_rows).await?;
 
-        if let DataTypeNode::Nullable(inner) = &data_type {
-            // Read off the null bitmap
-            self.read_bytes(num_rows).await?;
-
-            let null_map = self.buffer.split().freeze();
-
-            let (data, layout) = self.read_column_data(&name, &inner, num_rows).await?;
-
-            Ok(Column {
-                name,
-                data_type,
-                data,
-                layout,
-                null_map: Some(null_map),
-            })
-        } else {
-            let (data, layout) = self.read_column_data(&name, &data_type, num_rows).await?;
-
-            Ok(Column {
-                name,
-                data_type,
-                data,
-                layout,
-                null_map: None,
-            })
-        }
+        Ok(Column {
+            name,
+            data_type,
+            layout,
+            num_rows,
+        })
     }
 
-    async fn read_column_data(
+    async fn read_type_data(
         &mut self,
-        name: &MaybeUtf8,
         data_type: &DataTypeNode,
         num_rows: usize,
-    ) -> Result<(Bytes, Layout), Error> {
+    ) -> Result<Layout, Error> {
+        let (data_type, nulls) = if let DataTypeNode::Nullable(inner) = data_type {
+            // Read off the null bitmap
+            (&**inner, Some(self.read_bytes(num_rows).await?))
+        } else {
+            (data_type, None)
+        };
+
         if let Some(type_width) = fixed_width(data_type) {
-            let total_bytes = type_width
-                .checked_mul(num_rows)
-                .ok_or_else(|| Error::Custom(format!("data size of column {name:?} is too large: {num_rows} rows X {type_width} bytes")))?;
+            let total_bytes = type_width.checked_mul(num_rows).ok_or_else(|| {
+                Error::Custom(format!(
+                    "data size is too large: {num_rows} rows X {type_width} bytes"
+                ))
+            })?;
 
-            self.read_bytes(total_bytes).await?;
-
-            return Ok((self.buffer.split().freeze(), Layout::Fixed { type_width }));
+            return Ok(Layout {
+                kind: LayoutKind::Fixed {
+                    type_width,
+                    data: self.read_bytes(total_bytes).await?,
+                },
+                nulls,
+            });
         }
 
         match data_type {
             DataTypeNode::String => {
-                let mut offsets = Vec::with_capacity(num_rows);
+                // Assume default growth strategy is fine
+                let mut data = BytesMut::new();
+                let mut end_offsets = Vec::with_capacity(num_rows);
 
                 for row in 0..num_rows {
-                    offsets.push(self.buffer.marker);
                     let len = self.read_varuint().await?;
 
                     let len = usize::try_from(len).map_err(|_| {
-                        Error::Custom(format!(
-                            "string length {len} of row {row} of column {name:?} is out of range"
-                        ))
+                        Error::Custom(format!("string #{row} length {len} is out of range"))
                     })?;
 
-                    self.read_bytes(len).await?;
+                    self.read_bytes_into(len, &mut data).await?;
+                    end_offsets.push(data.len());
                 }
 
-                Ok((
-                    self.buffer.split().freeze(),
-                    Layout::Offsets(offsets.into()),
-                ))
+                Ok(Layout {
+                    kind: LayoutKind::Variable {
+                        data: data.freeze(),
+                        end_offsets: end_offsets.into(),
+                    },
+                    nulls,
+                })
             }
             DataTypeNode::Array(elem_type) => {
-                let mut lengths = Vec::with_capacity(num_rows);
-                let mut total_len = 0;
+                let mut end_indices = Vec::with_capacity(num_rows);
 
                 for _ in 0..num_rows {
                     // Note: cumulative length, last value is total number of elements
-                    let length = u64::from_le_bytes(self.read_bytes(8).await?.try_into().unwrap());
+                    let length = u64::from_le_bytes(self.read_bytes_fixed().await?);
 
                     let length = usize::try_from(length).map_err(|_| {
                         Error::Custom(format!("array length out of range: {length}"))
                     })?;
 
-                    lengths.push(length - total_len);
-                    total_len = length;
+                    end_indices.push(length);
                 }
 
-                self.buffer.split();
+                let total_len = end_indices.last().copied().unwrap_or(0);
 
-                if let Some(type_width) = fixed_width(elem_type) {
-                    if let Some(&total_len) = lengths.last() {
-                        let total_bytes = total_len
-                            .checked_mul(type_width)
-                            .ok_or_else(|| Error::Custom(format!("data size of column {name:?} is too large: {num_rows} rows X {type_width} bytes")))?;
+                // Recursive `async fn` currently requires boxing
+                let elem_layout = Box::pin(self.read_type_data(elem_type, total_len)).await?;
 
-                        self.read_bytes(total_bytes).await?;
-                    }
-
-                    return Ok((
-                        self.buffer.split().freeze(),
-                        Layout::Array {
-                            elem_layout: Box::new(Layout::Fixed { type_width }),
-                            cumulative_lengths: lengths.into(),
-                        },
-                    ));
-                }
-
-                todo!("Arrays of variable-length types")
+                Ok(Layout {
+                    kind: LayoutKind::Array {
+                        end_indices: end_indices.into(),
+                        elem_layout: Box::new(elem_layout),
+                    },
+                    nulls,
+                })
             }
             _ => Err(Error::Custom(format!(
-                "data type {data_type:?} of column {name:?} not implemented"
+                "data type {data_type:?} not implemented"
             ))),
         }
     }
@@ -200,99 +167,111 @@ impl BlockReader {
     }
 
     async fn read_varuint(&mut self) -> Result<u64, Error> {
+        let mut parser = ParseVarUInt::default();
+
         loop {
-            match self.buffer.read_varuint() {
-                ControlFlow::Break(res) => return res,
-                ControlFlow::Continue(_) => {
-                    let chunk = self
-                        .chunks
-                        .next()
-                        .await
-                        .transpose()?
-                        .ok_or_else(|| Error::NotEnoughData)?;
-                    self.buffer.push(chunk);
-                }
+            if let ControlFlow::Break(val) = parser.feed(&mut self.last_chunk)? {
+                return Ok(val);
             }
+
+            self.read_chunk().await?;
         }
     }
 
-    async fn read_bytes(&mut self, len: usize) -> Result<&[u8], Error> {
-        while self.buffer.tail().len() < len {
-            let chunk = self
-                .chunks
-                .next()
-                .await
-                .transpose()?
-                .ok_or_else(|| Error::NotEnoughData)?;
+    async fn read_bytes(&mut self, len: usize) -> Result<Bytes, Error> {
+        self.read_chunk().await?;
 
-            self.buffer.push(chunk);
+        if self.last_chunk.len() >= len {
+            return Ok(self.last_chunk.split_to(len));
         }
 
-        self.buffer.advance(len)
+        let mut buf = BytesMut::with_capacity(len);
+        self.read_bytes_into(len, &mut buf).await?;
+
+        Ok(buf.freeze())
+    }
+
+    async fn read_bytes_into(
+        &mut self,
+        mut read_len: usize,
+        buf: &mut BytesMut,
+    ) -> Result<(), Error> {
+        while read_len > 0 {
+            self.read_chunk().await?;
+
+            let data = self
+                .last_chunk
+                .split_to(cmp::min(read_len, self.last_chunk.len()));
+            buf.extend_from_slice(&data);
+            read_len -= data.len();
+        }
+
+        Ok(())
+    }
+
+    async fn read_bytes_fixed<const LEN: usize>(&mut self) -> Result<[u8; LEN], Error> {
+        let mut read_len = 0;
+        let mut buf = [0u8; LEN];
+
+        while read_len < LEN {
+            self.read_chunk().await?;
+
+            let amt = cmp::min(LEN - read_len, self.last_chunk.len());
+            buf[read_len..].copy_from_slice(&self.last_chunk[..amt]);
+            read_len += amt;
+            self.last_chunk.advance(amt);
+        }
+
+        Ok(buf)
+    }
+
+    async fn read_chunk(&mut self) -> Result<(), Error> {
+        if self.last_chunk.is_empty() {
+            self.last_chunk = self.chunks.next().await.ok_or(Error::NotEnoughData)??.data;
+        }
+
+        Ok(())
     }
 }
 
-impl Buffer {
-    fn push(&mut self, chunk: Chunk) {
-        self.bytes.extend_from_slice(&chunk.data);
-    }
-
-    fn split(&mut self) -> BytesMut {
-        let ret = self.bytes.split_to(self.marker);
-        self.marker = 0;
-        ret
-    }
-
-    fn tail(&self) -> &[u8] {
-        &self.bytes[self.marker..]
-    }
-
-    fn advance(&mut self, len: usize) -> Result<&[u8], Error> {
-        let ret = &self.bytes[self.marker..]
-            .get(..len)
-            .ok_or(Error::NotEnoughData)?;
-
-        self.marker += len;
-
-        Ok(ret)
-    }
-
-    fn read_varuint(&mut self) -> ControlFlow<Result<u64, Error>, usize> {
-        let mut tail = self.tail();
-
-        match parse_varuint(&mut tail) {
-            ControlFlow::Break(Ok(res)) => {
-                self.marker = self.bytes.len() - tail.len();
-                ControlFlow::Break(Ok(res))
-            }
-            other => other,
-        }
-    }
+#[derive(Default)]
+pub(super) struct ParseVarUInt {
+    accumulator: u64,
 }
 
-pub(super) fn parse_varuint(buf: &mut &[u8]) -> ControlFlow<Result<u64, Error>, usize> {
-    const MAX_LEN: usize = 10;
-
-    let mut accumulator = 0u64;
-
-    let mut iter = buf.iter();
-
-    for b in iter.by_ref().take(MAX_LEN) {
-        accumulator |= u64::from(b & 0x7F);
-        if *b >= 0x80 {
-            accumulator <<= 7;
-        } else {
-            *buf = iter.as_slice();
-            return ControlFlow::Break(Ok(accumulator));
-        }
+impl ParseVarUInt {
+    pub fn parse_full(buf: impl Buf) -> Result<u64, Error> {
+        Self::default()
+            .feed(buf)?
+            .break_value()
+            .ok_or(Error::NotEnoughData)
     }
 
-    if buf.len() < MAX_LEN {
-        ControlFlow::Continue(MAX_LEN - buf.len())
-    } else {
-        // TODO: better errors
-        ControlFlow::Break(Err(Error::Custom(format!(
-            "terminating byte missing in VarUInt encoding: {buf:?}",
-        ))))
+    pub fn feed(&mut self, mut buf: impl Buf) -> Result<ControlFlow<u64>, Error> {
+        const MAX_LEN: usize = 10;
+
+        for _ in 0..MAX_LEN {
+            let Ok(b) = buf.try_get_u8() else {
+                return Ok(ControlFlow::Continue(()));
+            };
+
+            self.accumulator |= u64::from(b & 0x7F);
+
+            if b >= 0x80 {
+                self.accumulator = self.accumulator.checked_shl(7).ok_or_else(|| {
+                    Error::Custom(format!(
+                        "VarUInt repr overflowed: {:016x} byte: {b:02x}",
+                        self.accumulator
+                    ))
+                })?;
+            } else {
+                return Ok(ControlFlow::Break(self.accumulator));
+            }
+        }
+
+        Err(Error::Custom(format!(
+            "terminating byte missing in VarUInt encoding: {:016x}",
+            self.accumulator,
+        )))
     }
 }

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -39,6 +39,12 @@ impl BlockReader {
         let num_columns = self.read_varuint().await?;
         let num_rows = self.read_varuint().await?;
 
+        let num_rows = usize::try_from(num_rows).map_err(|_| {
+            Error::Custom(format!(
+                "number of rows in block is out of range: {num_rows}"
+            ))
+        })?;
+
         if num_columns == 0 {
             return Ok(None);
         }
@@ -52,10 +58,10 @@ impl BlockReader {
             columns.push(self.read_column(num_rows).await?);
         }
 
-        Ok(Some(Block::from_columns(columns)))
+        Ok(Some(Block::from_columns(columns, num_rows)))
     }
 
-    async fn read_column(&mut self, num_rows: u64) -> Result<Column, Error> {
+    async fn read_column(&mut self, num_rows: usize) -> Result<Column, Error> {
         let name = self.read_string().await?;
         let data_type = self.read_string().await?;
 
@@ -75,14 +81,8 @@ impl BlockReader {
         self.buffer.split();
 
         if let Some(type_width) = super::fixed_width(&data_type) {
-            let rows_usize = usize::try_from(num_rows).map_err(|_| {
-                Error::Custom(format!(
-                    "number of rows in column {name:?} is out of range: {num_rows}"
-                ))
-            })?;
-
             let total_bytes = type_width
-                .checked_mul(rows_usize)
+                .checked_mul(num_rows)
                 .ok_or_else(|| Error::Custom(format!("data size of column {name:?} is too large: {num_rows} rows X {type_width} bytes")))?;
 
             self.read_bytes(total_bytes).await?;
@@ -95,9 +95,34 @@ impl BlockReader {
             });
         }
 
-        Err(Error::Custom(
-            "TODO: non-fixed-width column types not yet implemented".into(),
-        ))
+        match data_type {
+            DataTypeNode::String => {
+                let mut offsets = Vec::with_capacity(num_rows);
+
+                for row in 0..num_rows {
+                    offsets.push(self.buffer.marker);
+                    let len = self.read_varuint().await?;
+
+                    let len = usize::try_from(len).map_err(|_| {
+                        Error::Custom(format!(
+                            "string length {len} of row {row} of column {name:?} is out of range"
+                        ))
+                    })?;
+
+                    self.read_bytes(len).await?;
+                }
+
+                Ok(Column {
+                    name,
+                    data_type,
+                    data: self.buffer.split().freeze(),
+                    layout: Layout::Offsets(offsets.into()),
+                })
+            }
+            _ => Err(Error::Custom(format!(
+                "data type {data_type:?} of column {name:?} not implemented"
+            ))),
+        }
     }
 
     async fn read_string(&mut self) -> Result<MaybeUtf8, Error> {
@@ -111,7 +136,7 @@ impl BlockReader {
 
     async fn read_varuint(&mut self) -> Result<u64, Error> {
         loop {
-            match self.buffer.parse_varuint() {
+            match self.buffer.read_varuint() {
                 ControlFlow::Break(res) => return res,
                 ControlFlow::Continue(_) => {
                     let chunk = self
@@ -167,29 +192,42 @@ impl Buffer {
         Ok(ret)
     }
 
-    fn parse_varuint(&mut self) -> ControlFlow<Result<u64, Error>, usize> {
-        const MAX_LEN: usize = 10;
+    fn read_varuint(&mut self) -> ControlFlow<Result<u64, Error>, usize> {
+        let mut tail = self.tail();
 
-        let mut accumulator = 0u64;
-
-        for (pos, b) in self.tail().iter().enumerate().take(MAX_LEN) {
-            accumulator |= u64::from(b & 0x7F);
-            if b & 0x80 != 0 {
-                accumulator <<= 7;
-            } else {
-                self.marker += pos;
-                return ControlFlow::Break(Ok(accumulator));
+        match parse_varuint(&mut tail) {
+            ControlFlow::Break(Ok(res)) => {
+                self.marker = self.bytes.len() - tail.len();
+                ControlFlow::Break(Ok(res))
             }
+            other => other,
         }
+    }
+}
 
-        if self.tail().len() < MAX_LEN {
-            ControlFlow::Continue(MAX_LEN - self.tail().len())
+pub(super) fn parse_varuint(buf: &mut &[u8]) -> ControlFlow<Result<u64, Error>, usize> {
+    const MAX_LEN: usize = 10;
+
+    let mut accumulator = 0u64;
+
+    let mut iter = buf.iter();
+
+    for b in iter.by_ref().take(MAX_LEN) {
+        accumulator |= u64::from(b & 0x7F);
+        if *b >= 0x80 {
+            accumulator <<= 7;
         } else {
-            // TODO: better errors
-            ControlFlow::Break(Err(Error::Custom(format!(
-                "terminating byte missing in VarUInt encoding: {:?}",
-                self.tail()
-            ))))
+            *buf = iter.as_slice();
+            return ControlFlow::Break(Ok(accumulator));
         }
+    }
+
+    if buf.len() < MAX_LEN {
+        ControlFlow::Continue(MAX_LEN - buf.len())
+    } else {
+        // TODO: better errors
+        ControlFlow::Break(Err(Error::Custom(format!(
+            "terminating byte missing in VarUInt encoding: {buf:?}",
+        ))))
     }
 }

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -475,8 +475,9 @@ impl ReaderInner {
 }
 
 #[derive(Default)]
-pub(super) struct ParseVarUInt {
+struct ParseVarUInt {
     accumulator: u64,
+    shift: u32,
 }
 
 impl ParseVarUInt {
@@ -488,18 +489,18 @@ impl ParseVarUInt {
                 return Ok(ControlFlow::Continue(()));
             };
 
-            self.accumulator |= u64::from(b & 0x7F);
+            self.accumulator |= (b as u64 & 0x7F).checked_shl(self.shift).ok_or_else(|| {
+                Error::Custom(format!(
+                    "VarUInt repr overflowed: {:016x} byte: {b:02x}",
+                    self.accumulator
+                ))
+            })?;
 
-            if b >= 0x80 {
-                self.accumulator = self.accumulator.checked_shl(7).ok_or_else(|| {
-                    Error::Custom(format!(
-                        "VarUInt repr overflowed: {:016x} byte: {b:02x}",
-                        self.accumulator
-                    ))
-                })?;
-            } else {
+            if b <= 0x7F {
                 return Ok(ControlFlow::Break(self.accumulator));
             }
+
+            self.shift += 7;
         }
 
         Err(Error::Custom(format!(
@@ -534,6 +535,82 @@ impl LcKeyType {
             LcKeyType::UInt16 => 2,
             LcKeyType::UInt32 => 4,
             LcKeyType::UInt64 => 8,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ParseVarUInt;
+    use bytes::Buf;
+    use std::ops::ControlFlow;
+
+    #[test]
+    fn parse_varuint() {
+        let encoded_and_decoded: &[(&[u8], u64)] = &[
+            (&[0u8][..], 0u64),
+            (&[1], 1),
+            (&[127], 127),
+            (&[0x80, 0x01], 1 << 7),
+            (&[0x80, 0x80, 0x01], 1 << 14),
+            (&[0x80, 0x80, 0x80, 0x01], 1 << 21),
+            (&[0x80, 0x80, 0x80, 0x80, 0x01], 1 << 28),
+            (&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x1F], 0xFF_FF_FF_FF_FF),
+        ];
+
+        let pad_len = 16usize;
+
+        for (encoded, decoded) in encoded_and_decoded {
+            // Pad with junk data that must be ignored
+            let padded: Vec<_> = encoded
+                .iter()
+                .copied()
+                .chain((0..).cycle())
+                .take(pad_len)
+                .collect();
+
+            // Test feeding slices in different size chunks
+            for chunk_size in 1..=padded.len() {
+                let mut parser = ParseVarUInt::default();
+
+                let mut slice = &padded[..];
+
+                let mut last_remaining = slice.len();
+
+                loop {
+                    match parser.feed((&mut slice).take(chunk_size)) {
+                        Ok(ControlFlow::Break(res)) => {
+                            assert_eq!(
+                                res, *decoded,
+                                "invalid decoding; chunk_size: {chunk_size}, padded: {padded:?}, remaining: {slice:?}"
+                            );
+                            assert_eq!(
+                                slice.len(),
+                                padded.len() - encoded.len(),
+                                "extra data consumed: {slice:?}"
+                            );
+                            break;
+                        }
+                        Ok(ControlFlow::Continue(())) => {
+                            assert!(
+                                !slice.is_empty(),
+                                "full slice consumed without giving a result"
+                            );
+                            assert_ne!(
+                                slice.len(),
+                                last_remaining,
+                                "parser failed to make progress"
+                            );
+                            last_remaining = slice.len();
+                        }
+                        Err(e) => {
+                            panic!(
+                                "error: {e:?}, chunk_size: {chunk_size}, padded: {padded:?}, remaining: {slice:?}"
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -44,7 +44,7 @@ impl BlockReader {
         }
 
         // Remove the block header from the buffer
-        self.buffer.commit();
+        self.buffer.split();
 
         let mut columns = Vec::new();
 
@@ -71,19 +71,42 @@ impl BlockReader {
             ))
         })?;
 
-        let layout = if let Some(type_width) = super::fixed_width(&data_type) {
-            Layout::Fixed { type_width }
-        } else if let DataTypeNode::LowCardinality(_) = data_type {
-            Layout::LowCardinality(todo!())
-        } else {
-            Layout::Offsets(todo!())
-        };
+        // Split the column header from the data
+        self.buffer.split();
 
-        todo!()
+        if let Some(type_width) = super::fixed_width(&data_type) {
+            let rows_usize = usize::try_from(num_rows).map_err(|_| {
+                Error::Custom(format!(
+                    "number of rows in column {name:?} is out of range: {num_rows}"
+                ))
+            })?;
+
+            let total_bytes = type_width
+                .checked_mul(rows_usize)
+                .ok_or_else(|| Error::Custom(format!("data size of column {name:?} is too large: {num_rows} rows X {type_width} bytes")))?;
+
+            self.read_bytes(total_bytes).await?;
+
+            return Ok(Column {
+                name,
+                data_type,
+                data: self.buffer.split().freeze(),
+                layout: Layout::Fixed { type_width },
+            });
+        }
+
+        Err(Error::Custom(
+            "TODO: non-fixed-width column types not yet implemented".into(),
+        ))
     }
 
     async fn read_string(&mut self) -> Result<MaybeUtf8, Error> {
-        todo!()
+        let len = self.read_varuint().await?;
+
+        let len = usize::try_from(len)
+            .map_err(|_| Error::Custom(format!("string length too large: {len}")))?;
+
+        Ok(self.read_bytes(len).await?.into())
     }
 
     async fn read_varuint(&mut self) -> Result<u64, Error> {
@@ -102,14 +125,29 @@ impl BlockReader {
             }
         }
     }
+
+    async fn read_bytes(&mut self, len: usize) -> Result<&[u8], Error> {
+        while self.buffer.tail().len() < len {
+            let chunk = self
+                .chunks
+                .next()
+                .await
+                .transpose()?
+                .ok_or_else(|| Error::NotEnoughData)?;
+
+            self.buffer.push(chunk);
+        }
+
+        self.buffer.advance(len)
+    }
 }
 
 impl Buffer {
     fn push(&mut self, chunk: Chunk) {
-        self.bytes.extend(chunk.data);
+        self.bytes.extend_from_slice(&chunk.data);
     }
 
-    fn commit(&mut self) -> BytesMut {
+    fn split(&mut self) -> BytesMut {
         let ret = self.bytes.split_to(self.marker);
         self.marker = 0;
         ret

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -1,0 +1,157 @@
+use crate::error::Error;
+use crate::native::string::MaybeUtf8;
+use crate::native::{Block, Column, Layout};
+use crate::response::{Chunk, Chunks};
+use bytes::{Bytes, BytesMut};
+use clickhouse_types::DataTypeNode;
+use futures_util::StreamExt;
+use std::ops::ControlFlow;
+
+pub(crate) struct BlockReader {
+    chunks: Chunks,
+    buffer: Buffer,
+}
+
+struct Buffer {
+    bytes: BytesMut,
+    marker: usize,
+}
+
+impl BlockReader {
+    pub(crate) fn new(chunks: Chunks) -> Self {
+        BlockReader {
+            chunks,
+            buffer: Buffer {
+                bytes: BytesMut::new(),
+                marker: 0,
+            },
+        }
+    }
+
+    /// **NOT** cancel-safe. Intended to be wrapped in an async task for cancel-safety.
+    pub(crate) async fn read_block(&mut self) -> Result<Option<Block>, Error> {
+        if let Some(chunk) = self.chunks.next().await.transpose()? {
+            self.buffer.push(chunk);
+        } else if self.buffer.bytes.is_empty() {
+            return Ok(None);
+        };
+
+        let num_columns = self.read_varuint().await?;
+        let num_rows = self.read_varuint().await?;
+
+        if num_columns == 0 {
+            return Ok(None);
+        }
+
+        // Remove the block header from the buffer
+        self.buffer.commit();
+
+        let mut columns = Vec::new();
+
+        for _ in 0..num_columns {
+            columns.push(self.read_column(num_rows).await?);
+        }
+
+        Ok(Some(Block::from_columns(columns)))
+    }
+
+    async fn read_column(&mut self, num_rows: u64) -> Result<Column, Error> {
+        let name = self.read_string().await?;
+        let data_type = self.read_string().await?;
+
+        let data_type = data_type.try_as_str().ok_or_else(|| {
+            Error::Custom(format!(
+                "invalid data type {data_type:?} of column {name:?}"
+            ))
+        })?;
+
+        let data_type = DataTypeNode::new(data_type).map_err(|e| {
+            Error::Custom(format!(
+                "invalid data type {data_type:?} of column {name:?}: {e}"
+            ))
+        })?;
+
+        let layout = if let Some(type_width) = super::fixed_width(&data_type) {
+            Layout::Fixed { type_width }
+        } else if let DataTypeNode::LowCardinality(_) = data_type {
+            Layout::LowCardinality(todo!())
+        } else {
+            Layout::Offsets(todo!())
+        };
+
+        todo!()
+    }
+
+    async fn read_string(&mut self) -> Result<MaybeUtf8, Error> {
+        todo!()
+    }
+
+    async fn read_varuint(&mut self) -> Result<u64, Error> {
+        loop {
+            match self.buffer.parse_varuint() {
+                ControlFlow::Break(res) => return res,
+                ControlFlow::Continue(_) => {
+                    let chunk = self
+                        .chunks
+                        .next()
+                        .await
+                        .transpose()?
+                        .ok_or_else(|| Error::NotEnoughData)?;
+                    self.buffer.push(chunk);
+                }
+            }
+        }
+    }
+}
+
+impl Buffer {
+    fn push(&mut self, chunk: Chunk) {
+        self.bytes.extend(chunk.data);
+    }
+
+    fn commit(&mut self) -> BytesMut {
+        let ret = self.bytes.split_to(self.marker);
+        self.marker = 0;
+        ret
+    }
+
+    fn tail(&self) -> &[u8] {
+        &self.bytes[self.marker..]
+    }
+
+    fn advance(&mut self, len: usize) -> Result<&[u8], Error> {
+        let ret = &self.bytes[self.marker..]
+            .get(..len)
+            .ok_or(Error::NotEnoughData)?;
+
+        self.marker += len;
+
+        Ok(ret)
+    }
+
+    fn parse_varuint(&mut self) -> ControlFlow<Result<u64, Error>, usize> {
+        const MAX_LEN: usize = 10;
+
+        let mut accumulator = 0u64;
+
+        for (pos, b) in self.tail().iter().enumerate().take(MAX_LEN) {
+            accumulator |= u64::from(b & 0x7F);
+            if b & 0x80 != 0 {
+                accumulator <<= 7;
+            } else {
+                self.marker += pos;
+                return ControlFlow::Break(Ok(accumulator));
+            }
+        }
+
+        if self.tail().len() < MAX_LEN {
+            ControlFlow::Continue(MAX_LEN - self.tail().len())
+        } else {
+            // TODO: better errors
+            ControlFlow::Break(Err(Error::Custom(format!(
+                "terminating byte missing in VarUInt encoding: {:?}",
+                self.tail()
+            ))))
+        }
+    }
+}

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::native::string::MaybeUtf8;
-use crate::native::{Block, Column, Layout};
+use crate::native::{Block, Column, Layout, fixed_width};
 use crate::response::{Chunk, Chunks};
 use bytes::{Bytes, BytesMut};
 use clickhouse_types::DataTypeNode;
@@ -80,19 +80,48 @@ impl BlockReader {
         // Split the column header from the data
         self.buffer.split();
 
-        if let Some(type_width) = super::fixed_width(&data_type) {
+        if let DataTypeNode::Nullable(inner) = &data_type {
+            // Read off the null bitmap
+            self.read_bytes(num_rows).await?;
+
+            let null_map = self.buffer.split().freeze();
+
+            let (data, layout) = self.read_column_data(&name, &inner, num_rows).await?;
+
+            Ok(Column {
+                name,
+                data_type,
+                data,
+                layout,
+                null_map: Some(null_map),
+            })
+        } else {
+            let (data, layout) = self.read_column_data(&name, &data_type, num_rows).await?;
+
+            Ok(Column {
+                name,
+                data_type,
+                data,
+                layout,
+                null_map: None,
+            })
+        }
+    }
+
+    async fn read_column_data(
+        &mut self,
+        name: &MaybeUtf8,
+        data_type: &DataTypeNode,
+        num_rows: usize,
+    ) -> Result<(Bytes, Layout), Error> {
+        if let Some(type_width) = fixed_width(data_type) {
             let total_bytes = type_width
                 .checked_mul(num_rows)
                 .ok_or_else(|| Error::Custom(format!("data size of column {name:?} is too large: {num_rows} rows X {type_width} bytes")))?;
 
             self.read_bytes(total_bytes).await?;
 
-            return Ok(Column {
-                name,
-                data_type,
-                data: self.buffer.split().freeze(),
-                layout: Layout::Fixed { type_width },
-            });
+            return Ok((self.buffer.split().freeze(), Layout::Fixed { type_width }));
         }
 
         match data_type {
@@ -112,12 +141,48 @@ impl BlockReader {
                     self.read_bytes(len).await?;
                 }
 
-                Ok(Column {
-                    name,
-                    data_type,
-                    data: self.buffer.split().freeze(),
-                    layout: Layout::Offsets(offsets.into()),
-                })
+                Ok((
+                    self.buffer.split().freeze(),
+                    Layout::Offsets(offsets.into()),
+                ))
+            }
+            DataTypeNode::Array(elem_type) => {
+                let mut lengths = Vec::with_capacity(num_rows);
+                let mut total_len = 0;
+
+                for _ in 0..num_rows {
+                    // Note: cumulative length
+                    let length = u64::from_le_bytes(self.read_bytes(8).await?.try_into().unwrap());
+
+                    let length = usize::try_from(length).map_err(|_| {
+                        Error::Custom(format!("array length out of range: {length}"))
+                    })?;
+
+                    lengths.push(length - total_len);
+                    total_len = length;
+                }
+
+                self.buffer.split();
+
+                if let Some(type_width) = fixed_width(elem_type) {
+                    if let Some(&total_len) = lengths.last() {
+                        let total_bytes = total_len
+                            .checked_mul(type_width)
+                            .ok_or_else(|| Error::Custom(format!("data size of column {name:?} is too large: {num_rows} rows X {type_width} bytes")))?;
+
+                        self.read_bytes(total_bytes).await?;
+                    }
+
+                    return Ok((
+                        self.buffer.split().freeze(),
+                        Layout::FixedArray {
+                            type_width,
+                            lengths: lengths.into(),
+                        },
+                    ));
+                }
+
+                todo!("Arrays of variable-length types")
             }
             _ => Err(Error::Custom(format!(
                 "data type {data_type:?} of column {name:?} not implemented"

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -1,18 +1,19 @@
 use crate::error::Error;
 use crate::native::string::MaybeUtf8;
-use crate::native::{Block, Column, Layout, LayoutKind, LayoutLowCardinality, fixed_width};
+use crate::native::{Block, Column, Layout, LayoutKind, LayoutLowCardinality, type_fixed_width};
 use crate::response::Chunks;
 use bytes::{Buf, Bytes, BytesMut};
 use clickhouse_types::DataTypeNode;
 use futures_util::StreamExt;
-use hashbrown::{HashMap, hash_map};
 use std::cmp;
+use std::collections::VecDeque;
 use std::ops::ControlFlow;
-use std::sync::Arc;
 
 pub(crate) struct BlockReader {
     inner: ReaderInner,
-    lc_state: LcState,
+    // Since versioned type encoding is split into a "prefix phase" and a "data phase"
+    // we need to read state prefixes separately and remember what we've seen
+    prefix_queue: VecDeque<StatePrefix>,
 }
 
 struct ReaderInner {
@@ -20,13 +21,10 @@ struct ReaderInner {
     last_chunk: Bytes,
 }
 
-/// `LowCardinality` decode state for the current stream.
-struct LcState {
-    by_column: HashMap<MaybeUtf8, ColumnLcState>,
-}
-
-struct ColumnLcState {
-    global_dict: Option<Arc<Layout>>,
+#[derive(Debug)]
+enum StatePrefix {
+    // LowCardinality state prefix is just `version = 1`, no state necessary
+    LowCardinality,
 }
 
 #[repr(u64)]
@@ -45,9 +43,7 @@ impl BlockReader {
                 chunks,
                 last_chunk: Bytes::new(),
             },
-            lc_state: LcState {
-                by_column: HashMap::new(),
-            },
+            prefix_queue: VecDeque::new(),
         }
     }
 
@@ -99,7 +95,13 @@ impl BlockReader {
             ))
         })?;
 
-        let layout = self.read_type_data(&name, &data_type, num_rows).await?;
+        if num_rows != 0 {
+            self.read_state_prefix(&name, &data_type).await?;
+        }
+
+        let layout = self
+            .read_data(&name, &data_type, num_rows, num_rows != 0)
+            .await?;
 
         Ok(Column {
             name,
@@ -108,11 +110,59 @@ impl BlockReader {
         })
     }
 
-    async fn read_type_data(
+    async fn read_state_prefix(
+        &mut self,
+        column_name: &MaybeUtf8,
+        data_type: &DataTypeNode,
+    ) -> Result<(), Error> {
+        match data_type {
+            DataTypeNode::LowCardinality(_) => {
+                let prefix = self.inner.read_int64().await?;
+
+                if prefix != 1 {
+                    // sharedDictionariesWithAdditionalKeys
+                    return Err(Error::Custom(format!(
+                        "unexpected/unsupported serialization version of (sub)type \
+                             {data_type} of column {column_name:?}: \
+                             expected 1, got {prefix}"
+                    )));
+                }
+
+                self.prefix_queue.push_back(StatePrefix::LowCardinality);
+            }
+            // State prefix for composite types needs to be read _before_ the composite type layout
+            DataTypeNode::Array(inner_type) => {
+                Box::pin(self.read_state_prefix(column_name, inner_type)).await?;
+            }
+            DataTypeNode::Tuple(types) => {
+                for ty in types {
+                    Box::pin(self.read_state_prefix(column_name, ty)).await?;
+                }
+            }
+            DataTypeNode::Map([key_ty, val_ty]) => {
+                Box::pin(self.read_state_prefix(column_name, key_ty)).await?;
+                Box::pin(self.read_state_prefix(column_name, val_ty)).await?;
+            }
+            DataTypeNode::JSON
+            | DataTypeNode::JsonWithHint(_)
+            | DataTypeNode::Variant(_)
+            | DataTypeNode::Dynamic => {
+                return Err(Error::Custom(format!(
+                    "unimplemented deserialization of (sub)type {data_type} of column {column_name:?}"
+                )));
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+
+    async fn read_data(
         &mut self,
         column_name: &MaybeUtf8,
         data_type: &DataTypeNode,
         num_values: usize,
+        block_nonempty: bool,
     ) -> Result<Layout, Error> {
         let (data_type, nulls) = if let DataTypeNode::Nullable(inner) = data_type {
             // Read off the null bitmap
@@ -121,7 +171,7 @@ impl BlockReader {
             (data_type, None)
         };
 
-        if let Some(type_width) = fixed_width(data_type) {
+        if let Some(type_width) = type_fixed_width(data_type) {
             let total_bytes = type_width.checked_mul(num_values).ok_or_else(|| {
                 Error::Custom(format!(
                     "data size of column {column_name:?} is too large: {num_values} rows X {type_width} bytes"
@@ -171,7 +221,8 @@ impl BlockReader {
 
                 // Recursive `async fn` currently requires boxing
                 let elem_layout =
-                    Box::pin(self.read_type_data(column_name, elem_type, total_len)).await?;
+                    Box::pin(self.read_data(column_name, elem_type, total_len, block_nonempty))
+                        .await?;
 
                 Ok(Layout {
                     kind: LayoutKind::Array {
@@ -186,7 +237,10 @@ impl BlockReader {
                 let mut layouts = Vec::with_capacity(types.len());
 
                 for ty in types {
-                    layouts.push(Box::pin(self.read_type_data(column_name, ty, num_values)).await?);
+                    layouts.push(
+                        Box::pin(self.read_data(column_name, ty, num_values, block_nonempty))
+                            .await?,
+                    );
                 }
 
                 Ok(Layout {
@@ -204,12 +258,12 @@ impl BlockReader {
 
                 let total_len = end_indices.last().copied().unwrap_or(0);
 
-                // Keys semantically cannot be `LowCardinality` or `Nullable`
-                // but that doesn't really affect decoding
                 let key_layout =
-                    Box::pin(self.read_type_data(column_name, key_ty, total_len)).await?;
+                    Box::pin(self.read_data(column_name, key_ty, total_len, block_nonempty))
+                        .await?;
                 let value_layout =
-                    Box::pin(self.read_type_data(column_name, val_ty, total_len)).await?;
+                    Box::pin(self.read_data(column_name, val_ty, total_len, block_nonempty))
+                        .await?;
 
                 Ok(Layout {
                     kind: LayoutKind::Map {
@@ -223,11 +277,11 @@ impl BlockReader {
             DataTypeNode::LowCardinality(inner_type) => {
                 Ok(Layout {
                     kind: LayoutKind::LowCardinality(
-                        self.read_low_cardinality(column_name, inner_type, num_values)
+                        self.read_lc_data(column_name, inner_type, num_values, block_nonempty)
                             .await?,
                     ),
-                    // Can be `Some` if the type is `Nullable(LowCardinality(...))`
-                    // even though `LowCardinality(Nullable(...))` is more efficient
+                    // Server disallows `Nullable(LowCardinality(...))` but we don't gain much
+                    // from asserting that here
                     nulls,
                     num_values,
                 })
@@ -238,57 +292,73 @@ impl BlockReader {
         }
     }
 
-    async fn read_low_cardinality(
+    async fn read_lc_data(
         &mut self,
         column_name: &MaybeUtf8,
         inner_type: &DataTypeNode,
         num_rows: usize,
+        block_nonempty: bool,
     ) -> Result<LayoutLowCardinality, Error> {
         const HAS_ADDITIONAL_KEYS_BIT: u64 = 0x200;
         const NEEDS_UPDATE_DICTIONARY_BIT: u64 = 0x400;
-        const NEED_GLOBAL_DICTIONARY_BIT: u64 = 0x800;
 
-        if num_rows == 0 {
-            todo!("empty result contains no prefix");
-        }
+        // NEED_GLOBAL_DICTIONARY_BIT (0x800) should NEVER be set
+        const VALID_FLAG_BITS: u64 = HAS_ADDITIONAL_KEYS_BIT | NEEDS_UPDATE_DICTIONARY_BIT;
 
-        if let hash_map::EntryRef::Vacant(vacant) = self.lc_state.by_column.entry_ref(column_name) {
-            // We haven't seen the state prefix for this query yet
-            let prefix = self.inner.read_int64().await?;
-
-            if prefix != 1 {
-                // sharedDictionariesWithAdditionalKeys
-                return Err(Error::Custom(format!(
-                    "unexpected/unsupported serialization version of type \
-                             LowCardinality({inner_type}) of column {column_name:?}: \
-                             expected 1, got {prefix}"
-                )));
-            }
-
-            vacant.insert(ColumnLcState { global_dict: None });
-        };
-
-        let metadata = self.inner.read_uint64().await?;
-
-        let key_type = LcKeyType::try_from_metadata(metadata)?;
-
-        let has_additional_keys = metadata & HAS_ADDITIONAL_KEYS_BIT != 0;
-        let needs_update_dictionary = metadata & NEEDS_UPDATE_DICTIONARY_BIT != 0;
-        let need_global_dictionary = metadata & NEED_GLOBAL_DICTIONARY_BIT != 0;
-
-        let dict_len = self.inner.read_uint64().await?;
-        let dict_len = usize::try_from(dict_len)
-            .map_err(|_| Error::Custom(format!("column {column_name:?} type LowCardinality({inner_type}) dictionary size too large: {dict_len}")))?;
-
-        // `LowCardinality(Nullable)` doesn't emit a null map, instead `dict[1]` is the null value
+        // `LowCardinality(Nullable)` doesn't emit a null map, instead `dict[0]` is the null value
         let (non_nullable, is_nullable) = if let DataTypeNode::Nullable(inner) = inner_type {
             (&**inner, true)
         } else {
             (inner_type, false)
         };
 
+        // Array(LowCardinality(...)) still emits a prefix even if the array itself is empty
+        if block_nonempty {
+            // Ensure that we read our version prefix even if it doesn't tell us anything
+            match self.prefix_queue.pop_front() {
+                Some(StatePrefix::LowCardinality) => (),
+                other => {
+                    return Err(Error::Custom(format!(
+                        "error reading column {column_name:?} (sub)type LowCardinality({inner_type}): \
+                     expected state prefix 0x01, got {other:?}"
+                    )));
+                }
+            }
+        }
+
+        if num_rows == 0 {
+            return Ok(LayoutLowCardinality {
+                keys: Box::new([]),
+                dict: Box::new(
+                    // The easiest way to implement this is to delegate back to `read_type_data()`
+                    Box::pin(self.read_data(column_name, non_nullable, num_rows, block_nonempty))
+                        .await?,
+                ),
+                is_nullable,
+            });
+        }
+
+        let metadata = self.inner.read_uint64().await?;
+
+        let key_type = LcKeyType::try_from_metadata(metadata)?;
+
+        let flags = metadata & !LcKeyType::MASK;
+
+        if flags != VALID_FLAG_BITS {
+            return Err(Error::Custom(format!(
+                "column {column_name:?} (sub)type LowCardinality({inner_type}) has \
+                         invalid or unexpected metadata bits (metadata: {metadata:X}); \
+                         expected: {VALID_FLAG_BITS:X}, received: {flags:X}",
+            )));
+        }
+
+        let dict_len = self.inner.read_uint64().await?;
+        let dict_len = usize::try_from(dict_len)
+            .map_err(|_| Error::Custom(format!("column {column_name:?} type LowCardinality({inner_type}) dictionary size too large: {dict_len}")))?;
+
         // called from `self.read_type_data()` so we have to box
-        let dict = Box::pin(self.read_type_data(column_name, non_nullable, dict_len)).await?;
+        let dict =
+            Box::pin(self.read_data(column_name, non_nullable, dict_len, block_nonempty)).await?;
 
         let keys_len = self.inner.read_uint64().await?;
         let keys_len = usize::try_from(keys_len)
@@ -302,33 +372,9 @@ impl BlockReader {
 
         let keys = self.inner.read_lc_keys(key_type, num_rows).await?;
 
-        // Cannot be borrowed across other calls to `self` so we have to do a second lookup;
-        // we could amortize by using `IndexMap` but two lookups per column is unlikely to be an issue
-        let state = self
-            .lc_state
-            .by_column
-            .get_mut(column_name)
-            .unwrap_or_else(|| panic!("BUG: `lc_state` should have been initialized"));
-
-        let (global_dict, local_dict) = if need_global_dictionary {
-            let global_dict = state.global_dict
-                .clone()
-                .ok_or_else(|| Error::Custom(format!("column {column_name:?} type LowCardinality({inner_type}) set NEEDS_GLOBAL_DICTIONARY_BIT for a block but no global dictionary was read")))?;
-
-            (
-                Some(global_dict),
-                has_additional_keys.then(|| Box::new(dict)),
-            )
-        } else if needs_update_dictionary {
-            (Some(state.global_dict.insert(Arc::new(dict)).clone()), None)
-        } else {
-            (None, Some(Box::new(dict)))
-        };
-
         Ok(LayoutLowCardinality {
-            global_dict,
-            local_dict,
             keys,
+            dict: Box::new(dict),
             is_nullable,
         })
     }

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -53,6 +53,12 @@ impl BlockReader {
 
     /// **NOT** cancel-safe. Intended to be wrapped in an async task for cancel-safety.
     pub(crate) async fn read_block(&mut self) -> Result<Option<Block>, Error> {
+        if !self.inner.try_read_chunk().await? {
+            // Native format over HTTP doesn't send a zero-row block on an empty resultset,
+            // it just sends nothing at all.
+            return Ok(None);
+        }
+
         let num_columns = self.inner.read_varuint().await?;
         let num_rows = self.inner.read_varuint().await?;
 
@@ -456,11 +462,24 @@ impl ReaderInner {
     }
 
     async fn read_chunk(&mut self) -> Result<(), Error> {
-        if self.last_chunk.is_empty() {
-            self.last_chunk = self.chunks.next().await.ok_or(Error::NotEnoughData)??.data;
+        if !self.try_read_chunk().await? {
+            tracing::trace!("error: not enough data");
+            return Err(Error::NotEnoughData);
         }
 
         Ok(())
+    }
+
+    async fn try_read_chunk(&mut self) -> Result<bool, Error> {
+        if self.last_chunk.is_empty() {
+            let Some(chunk) = self.chunks.next().await else {
+                return Ok(false);
+            };
+
+            self.last_chunk = chunk?.data;
+        }
+
+        Ok(true)
     }
 
     fn consume(&mut self, len: usize) {

--- a/src/native/reader.rs
+++ b/src/native/reader.rs
@@ -7,6 +7,7 @@ use clickhouse_types::DataTypeNode;
 use futures_util::StreamExt;
 use std::cmp;
 use std::collections::VecDeque;
+use std::fmt::{Display, Formatter};
 use std::ops::ControlFlow;
 
 pub(crate) struct BlockReader {
@@ -14,6 +15,17 @@ pub(crate) struct BlockReader {
     // Since versioned type encoding is split into a "prefix phase" and a "data phase"
     // we need to read state prefixes separately and remember what we've seen
     prefix_queue: VecDeque<StatePrefix>,
+}
+
+/// Captures errors that may occur while decoding a [Native Format] block.
+///
+/// [Native Format]: https://clickhouse.com/docs/reference/interfaces/specs/NativeFormat
+#[derive(Debug)]
+pub struct BlockReadError {
+    message: String,
+    column_name: Option<MaybeUtf8>,
+    column_type: Option<DataTypeNode>,
+    source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 }
 
 struct ReaderInner {
@@ -35,6 +47,23 @@ enum LcKeyType {
     UInt32,
     UInt64,
 }
+
+macro_rules! read_error {
+    ($($format_args:tt)*) => {
+        BlockReadError {
+            message: format!($($format_args)*),
+            column_name: None,
+            column_type: None,
+            source: None,
+        }
+    }
+}
+
+/// Maximum number of values allowed in any one column.
+///
+/// This is a hardcoded limit, not expected to be reached by any practical application,
+/// meant to guard against allocating based on malicious or malformed data.
+const SAFE_ALLOCATION_LIMIT: usize = 1 << 32;
 
 impl BlockReader {
     pub(crate) fn new(chunks: Chunks) -> Self {
@@ -58,11 +87,15 @@ impl BlockReader {
         let num_columns = self.inner.read_varuint().await?;
         let num_rows = self.inner.read_varuint().await?;
 
-        let num_rows = usize::try_from(num_rows).map_err(|_| {
-            Error::Custom(format!(
-                "number of rows in block is out of range: {num_rows}"
-            ))
-        })?;
+        let num_rows = usize::try_from(num_rows)
+            .map_err(|_| read_error!("number of rows in block is out of range: {num_rows}"))?;
+
+        if num_rows > SAFE_ALLOCATION_LIMIT {
+            return Err(read_error!(
+                "number of rows in block exceeds safe limit: {num_rows} vs {SAFE_ALLOCATION_LIMIT}"
+            )
+            .into());
+        }
 
         if num_columns == 0 {
             return Ok(None);
@@ -84,24 +117,26 @@ impl BlockReader {
         let data_type = self.inner.read_string().await?;
 
         let data_type = data_type.as_str().ok_or_else(|| {
-            Error::Custom(format!(
-                "invalid data type {data_type:?} of column {name:?}"
-            ))
+            read_error!("invalid data type {data_type:?}").with_column(&name, None)
         })?;
 
         let data_type = DataTypeNode::new(data_type).map_err(|e| {
-            Error::Custom(format!(
-                "invalid data type {data_type:?} of column {name:?}: {e}"
-            ))
+            read_error!("error parsing data type {data_type:?}")
+                .with_column(&name, None)
+                .with_source(e)
         })?;
 
         if num_rows != 0 {
-            self.read_state_prefix(&name, &data_type).await?;
+            self.read_state_prefix(&name, &data_type)
+                .await
+                // so every error message doesn't have to manually mention the column name/type
+                .err_with_column(&name, Some(&data_type))?;
         }
 
         let layout = self
             .read_data(&name, &data_type, num_rows, num_rows != 0)
-            .await?;
+            .await
+            .err_with_column(&name, Some(&data_type))?;
 
         Ok(Column {
             name,
@@ -121,11 +156,11 @@ impl BlockReader {
 
                 if prefix != 1 {
                     // sharedDictionariesWithAdditionalKeys
-                    return Err(Error::Custom(format!(
-                        "unexpected/unsupported serialization version of (sub)type \
-                             {data_type} of column {column_name:?}: \
-                             expected 1, got {prefix}"
-                    )));
+                    return Err(read_error!(
+                        "unexpected/unsupported serialization version of LowCardinality: \
+                         expected 1, got {prefix}"
+                    )
+                    .into());
                 }
 
                 self.prefix_queue.push_back(StatePrefix::LowCardinality);
@@ -147,9 +182,9 @@ impl BlockReader {
             | DataTypeNode::JsonWithHint(_)
             | DataTypeNode::Variant(_)
             | DataTypeNode::Dynamic => {
-                return Err(Error::Custom(format!(
-                    "unimplemented deserialization of (sub)type {data_type} of column {column_name:?}"
-                )));
+                return Err(
+                    read_error!("unimplemented deserialization of (sub)type {data_type}").into(),
+                );
             }
             _ => (),
         }
@@ -164,6 +199,15 @@ impl BlockReader {
         num_values: usize,
         block_nonempty: bool,
     ) -> Result<Layout, Error> {
+        if num_values > SAFE_ALLOCATION_LIMIT {
+            // Ideally one of the other checks will give the user a more specific error message.
+            return Err(read_error!(
+                "number of values exceeds safe allocation limit: \
+                 {num_values} vs {SAFE_ALLOCATION_LIMIT}"
+            )
+            .into());
+        }
+
         let (data_type, nulls) = if let DataTypeNode::Nullable(inner) = data_type {
             // Read off the null bitmap
             (&**inner, Some(self.inner.read_bytes(num_values).await?))
@@ -173,9 +217,7 @@ impl BlockReader {
 
         if let Some(type_width) = type_fixed_width(data_type) {
             let total_bytes = type_width.checked_mul(num_values).ok_or_else(|| {
-                Error::Custom(format!(
-                    "data size of column {column_name:?} is too large: {num_values} rows X {type_width} bytes"
-                ))
+                read_error!("data size is too large: {num_values} rows X {type_width} bytes")
             })?;
 
             return Ok(Layout {
@@ -197,9 +239,8 @@ impl BlockReader {
                 for row in 0..num_values {
                     let len = self.inner.read_varuint().await?;
 
-                    let len = usize::try_from(len).map_err(|_| {
-                        Error::Custom(format!("string #{row} length {len} is out of range"))
-                    })?;
+                    let len = usize::try_from(len)
+                        .map_err(|_| read_error!("string #{row} length {len} is out of range"))?;
 
                     self.inner.read_bytes_into(len, &mut data).await?;
                     end_offsets.push(data.len());
@@ -218,6 +259,14 @@ impl BlockReader {
                 let end_indices = self.inner.read_array_indices(num_values).await?;
 
                 let total_len = end_indices.last().copied().unwrap_or(0);
+
+                if total_len > SAFE_ALLOCATION_LIMIT {
+                    return Err(read_error!(
+                        "total length of arrays in column exceeds safe limit: \
+                         {total_len} vs {SAFE_ALLOCATION_LIMIT}"
+                    )
+                    .into());
+                }
 
                 // Recursive `async fn` currently requires boxing
                 let elem_layout =
@@ -258,6 +307,14 @@ impl BlockReader {
 
                 let total_len = end_indices.last().copied().unwrap_or(0);
 
+                if total_len > SAFE_ALLOCATION_LIMIT {
+                    return Err(read_error!(
+                        "total number of map entries exceeds safe limit: \
+                         {total_len} vs {SAFE_ALLOCATION_LIMIT}"
+                    )
+                    .into());
+                }
+
                 let key_layout =
                     Box::pin(self.read_data(column_name, key_ty, total_len, block_nonempty))
                         .await?;
@@ -286,9 +343,7 @@ impl BlockReader {
                     num_values,
                 })
             }
-            _ => Err(Error::Custom(format!(
-                "data type {data_type:?} not implemented"
-            ))),
+            _ => Err(read_error!("data type {data_type:?} not implemented").into()),
         }
     }
 
@@ -318,10 +373,11 @@ impl BlockReader {
             match self.prefix_queue.pop_front() {
                 Some(StatePrefix::LowCardinality) => (),
                 other => {
-                    return Err(Error::Custom(format!(
-                        "error reading column {column_name:?} (sub)type LowCardinality({inner_type}): \
-                     expected state prefix 0x01, got {other:?}"
-                    )));
+                    return Err(read_error!(
+                        "error reading (sub)type LowCardinality({inner_type}): \
+                         expected state prefix 0x01, got {other:?}"
+                    )
+                    .into());
                 }
             }
         }
@@ -345,29 +401,37 @@ impl BlockReader {
         let flags = metadata & !LcKeyType::MASK;
 
         if flags != VALID_FLAG_BITS {
-            return Err(Error::Custom(format!(
-                "column {column_name:?} (sub)type LowCardinality({inner_type}) has \
-                         invalid or unexpected metadata bits (metadata: {metadata:X}); \
-                         expected: {VALID_FLAG_BITS:X}, received: {flags:X}",
-            )));
+            return Err(read_error!(
+                "(sub)type LowCardinality({inner_type}) has \
+                 invalid or unexpected metadata bits (metadata: {metadata:X}); \
+                 expected: {VALID_FLAG_BITS:X}, received: {flags:X}",
+            )
+            .into());
         }
 
         let dict_len = self.inner.read_uint64().await?;
-        let dict_len = usize::try_from(dict_len)
-            .map_err(|_| Error::Custom(format!("column {column_name:?} type LowCardinality({inner_type}) dictionary size too large: {dict_len}")))?;
+        let dict_len = usize::try_from(dict_len).map_err(|_| {
+            read_error!("LowCardinality({inner_type}) dictionary size too large: {dict_len}")
+        })?;
 
         // called from `self.read_type_data()` so we have to box
-        let dict =
-            Box::pin(self.read_data(column_name, non_nullable, dict_len, block_nonempty)).await?;
+        let dict = Box::pin(self.read_data(column_name, non_nullable, dict_len, block_nonempty))
+            .await
+            .map_err(|e| {
+                read_error!("error reading LowCardinality({inner_type}) dictionary").with_source(e)
+            })?;
 
         let keys_len = self.inner.read_uint64().await?;
-        let keys_len = usize::try_from(keys_len)
-            .map_err(|_| Error::Custom(format!("column {column_name:?} type LowCardinality({inner_type}) keys count too large: {keys_len}")))?;
+        let keys_len = usize::try_from(keys_len).map_err(|_| {
+            read_error!("LowCardinality({inner_type}) keys count too large: {keys_len}")
+        })?;
 
         if keys_len != num_rows {
-            return Err(Error::Custom(format!(
-                "column {column_name:?} type LowCardinality({inner_type}) keys count does not match number of rows in block: {keys_len} vs {num_rows}; this likely means a bug or corrupted data"
-            )));
+            return Err(read_error!(
+                "LowCardinality({inner_type}) keys count does not match number of rows in block: \
+                 {keys_len} vs {num_rows}; this likely means a bug or corrupted data"
+            )
+            .into());
         }
 
         let keys = self.inner.read_lc_keys(key_type, num_rows).await?;
@@ -384,8 +448,15 @@ impl ReaderInner {
     async fn read_string(&mut self) -> Result<MaybeUtf8, Error> {
         let len = self.read_varuint().await?;
 
-        let len = usize::try_from(len)
-            .map_err(|_| Error::Custom(format!("string length too large: {len}")))?;
+        let len =
+            usize::try_from(len).map_err(|_| read_error!("string length too large: {len}"))?;
+
+        if len > SAFE_ALLOCATION_LIMIT {
+            return Err(read_error!(
+                "string size exceeds safe allocation limit: {len} vs {SAFE_ALLOCATION_LIMIT}"
+            )
+            .into());
+        }
 
         Ok(self.read_bytes(len).await?.into())
     }
@@ -410,7 +481,7 @@ impl ReaderInner {
             let length = self.read_uint64().await?;
 
             let length = usize::try_from(length)
-                .map_err(|_| Error::Custom(format!("array length out of range: {length}")))?;
+                .map_err(|_| read_error!("array length out of range: {length}"))?;
 
             end_indices.push(length);
         }
@@ -433,9 +504,10 @@ impl ReaderInner {
             let key = u64::from_le_bytes(buf);
 
             let key = usize::try_from(key).map_err(|_| {
-                Error::Custom(format!(
-                    "LowCardinality dictionary key out of range at index {i}: {key}"
-                ))
+                Error::DataFormat(
+                    format!("LowCardinality dictionary key out of range at index {i}: {key}")
+                        .into(),
+                )
             })?;
 
             keys.push(key);
@@ -462,6 +534,15 @@ impl ReaderInner {
     }
 
     async fn read_bytes_into(&mut self, mut amt: usize, buf: &mut BytesMut) -> Result<(), Error> {
+        let expected_len = buf.len().saturating_add(amt);
+
+        if expected_len > SAFE_ALLOCATION_LIMIT {
+            return Err(read_error!(
+                "safe allocation limit exceeded: {expected_len} vs {SAFE_ALLOCATION_LIMIT}"
+            )
+            .into());
+        }
+
         while amt > 0 {
             self.read_chunk().await?;
 
@@ -559,10 +640,10 @@ impl ParseVarUInt {
             };
 
             self.accumulator |= (b as u64 & 0x7F).checked_shl(self.shift).ok_or_else(|| {
-                Error::Custom(format!(
+                read_error!(
                     "VarUInt repr overflowed: {:016x} byte: {b:02x}",
                     self.accumulator
-                ))
+                )
             })?;
 
             if b <= 0x7F {
@@ -572,10 +653,11 @@ impl ParseVarUInt {
             self.shift += 7;
         }
 
-        Err(Error::Custom(format!(
+        Err(read_error!(
             "terminating byte missing in VarUInt encoding: {:016x}",
             self.accumulator,
-        )))
+        )
+        .into())
     }
 }
 
@@ -591,9 +673,7 @@ impl LcKeyType {
             2 => Self::UInt32,
             3 => Self::UInt64,
             unknown => {
-                return Err(Error::Custom(format!(
-                    "unknown LowCardinality key type: {unknown}"
-                )));
+                return Err(read_error!("unknown LowCardinality key type: {unknown}").into());
             }
         })
     }
@@ -605,6 +685,99 @@ impl LcKeyType {
             LcKeyType::UInt32 => 4,
             LcKeyType::UInt64 => 8,
         }
+    }
+}
+
+impl Display for BlockReadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "error reading native block")?;
+
+        match (&self.column_name, &self.column_type) {
+            (Some(col_name), Some(col_type)) => {
+                write!(f, " at column `{col_name} {col_type}`")?;
+            }
+            (Some(col_name), None) => {
+                write!(f, " at column `{col_name}`")?;
+            }
+            _ => (),
+        }
+
+        write!(f, ": {}", self.message)
+    }
+}
+
+impl std::error::Error for BlockReadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        // `self.source.as_deref()` on its own doesn't trigger the correct coercion
+        Some(self.source.as_deref()?)
+    }
+}
+
+impl BlockReadError {
+    fn with_column(mut self, name: &MaybeUtf8, ty: Option<&DataTypeNode>) -> Self {
+        self.set_column(name, ty);
+        self
+    }
+
+    fn set_column(&mut self, name: &MaybeUtf8, ty: Option<&DataTypeNode>) {
+        self.column_name = Some(name.clone());
+        self.column_type = ty.cloned();
+    }
+
+    fn with_source(
+        mut self,
+        source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        self.source = Some(source.into());
+        self
+    }
+
+    /// Get the name of the column that was being read when the error occurred.
+    ///
+    /// Returns `None` if a column was not being read yet, or if the column name is not UTF-8.
+    ///
+    /// See [`Self::column_name_bytes()`] if handling column names that may not be UTF-8.
+    pub fn column_name(&self) -> Option<&str> {
+        self.column_name.as_ref().and_then(MaybeUtf8::as_str)
+    }
+
+    /// Get the name of the column that was being read when the error occurred.
+    ///
+    /// Returns `None` if a column was not being read yet.
+    pub fn column_name_bytes(&self) -> Option<&[u8]> {
+        self.column_name.as_ref().map(MaybeUtf8::as_bytes)
+    }
+}
+
+trait ResultExt {
+    fn err_with_column(self, name: &MaybeUtf8, data_type: Option<&DataTypeNode>) -> Self;
+}
+
+impl<T> ResultExt for Result<T, crate::Error> {
+    fn err_with_column(self, name: &MaybeUtf8, data_type: Option<&DataTypeNode>) -> Self {
+        let Err(e) = self else {
+            return self;
+        };
+
+        let Error::DataFormat(e) = e else {
+            return Err(e);
+        };
+
+        Err(Error::DataFormat(
+            e.downcast::<BlockReadError>().map_or_else(
+                |e| e,
+                |mut e| {
+                    e.set_column(name, data_type);
+                    e
+                },
+            ),
+        ))
+    }
+}
+
+impl<T> ResultExt for Result<T, BlockReadError> {
+    fn err_with_column(self, name: &MaybeUtf8, data_type: Option<&DataTypeNode>) -> Self {
+        self.map_err(|e| e.with_column(name, data_type))
     }
 }
 

--- a/src/native/string.rs
+++ b/src/native/string.rs
@@ -96,3 +96,9 @@ impl Debug for MaybeUtf8 {
         }
     }
 }
+
+impl hashbrown::Equivalent<MaybeUtf8> for str {
+    fn equivalent(&self, key: &MaybeUtf8) -> bool {
+        key == self
+    }
+}

--- a/src/native/string.rs
+++ b/src/native/string.rs
@@ -73,7 +73,7 @@ impl Hash for MaybeUtf8 {
 /// Compares lexicographically regardless of UTF-8-ness.
 impl PartialOrd for MaybeUtf8 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.as_bytes().cmp(other.as_bytes()))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/native/string.rs
+++ b/src/native/string.rs
@@ -1,40 +1,61 @@
+use bytes::Bytes;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 
 #[derive(Clone, PartialEq, Eq)]
-pub struct MaybeUtf8(Repr);
-
-#[derive(Clone, PartialEq, Eq)]
-enum Repr {
-    Utf8(Arc<str>),
-    NotUtf8(Arc<[u8]>),
+pub struct MaybeUtf8 {
+    bytes: Bytes,
+    // SAFETY: must not change for the lifetime of this object
+    is_utf8: bool,
 }
 
-impl From<&[u8]> for MaybeUtf8 {
-    fn from(value: &[u8]) -> Self {
-        Self(
-            str::from_utf8(value)
-                .map_or_else(|_| Repr::NotUtf8(value.into()), |s| Repr::Utf8(s.into())),
-        )
+impl MaybeUtf8 {
+    pub fn new<T: Into<Bytes>>(bytes: T) -> Self {
+        Self::from(bytes.into())
+    }
+}
+
+impl From<Bytes> for MaybeUtf8 {
+    fn from(bytes: Bytes) -> Self {
+        Self {
+            is_utf8: str::from_utf8(&bytes).is_ok(),
+            bytes,
+        }
+    }
+}
+
+impl From<String> for MaybeUtf8 {
+    fn from(value: String) -> Self {
+        Self {
+            bytes: value.into(),
+            is_utf8: true,
+        }
+    }
+}
+
+impl From<&'static str> for MaybeUtf8 {
+    fn from(value: &'static str) -> Self {
+        Self {
+            bytes: value.into(),
+            is_utf8: true,
+        }
     }
 }
 
 impl MaybeUtf8 {
+    pub fn is_utf8(&self) -> bool {
+        self.is_utf8
+    }
+
     pub fn as_bytes(&self) -> &[u8] {
-        match &self.0 {
-            Repr::Utf8(s) => s.as_bytes(),
-            Repr::NotUtf8(s) => s,
-        }
+        &self.bytes
     }
 
     pub fn try_as_str(&self) -> Option<&str> {
-        // The invariants of the type guarantee that we don't need to re-validate here
-        match &self.0 {
-            Repr::Utf8(s) => Some(s),
-            Repr::NotUtf8(_) => None,
-        }
+        // SAFETY: UTF-8 validity is checked on construction
+        self.is_utf8
+            .then(|| unsafe { str::from_utf8_unchecked(&self.bytes) })
     }
 }
 
@@ -42,9 +63,9 @@ impl Hash for MaybeUtf8 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Produce the same hash as `&[u8]` or `&str`;
         // `impl Hash for str` adds a domain-separation postfix so its routine is separate.
-        match &self.0 {
-            Repr::Utf8(s) => s.hash(state),
-            Repr::NotUtf8(s) => s.hash(state),
+        match self.try_as_str() {
+            Some(s) => s.hash(state),
+            None => self.bytes.hash(state),
         }
     }
 }
@@ -88,11 +109,9 @@ impl PartialEq<[u8]> for MaybeUtf8 {
 
 impl Debug for MaybeUtf8 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match &self.0 {
-            Repr::Utf8(s) => Debug::fmt(s, f),
-            Repr::NotUtf8(s) => {
-                write!(f, "\"{}\"", s.escape_ascii())
-            }
+        match self.try_as_str() {
+            Some(s) => Debug::fmt(s, f),
+            None => write!(f, "\"{}\"", self.bytes.escape_ascii()),
         }
     }
 }

--- a/src/native/string.rs
+++ b/src/native/string.rs
@@ -1,18 +1,36 @@
 use bytes::Bytes;
 use std::cmp::Ordering;
+use std::convert::Infallible;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
+use std::str::FromStr;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct MaybeUtf8 {
     bytes: Bytes,
-    // SAFETY: must not change for the lifetime of this object
+    /// SAFETY: must not change for the lifetime of this object, must be valid UTF-8 on construction
     is_utf8: bool,
 }
 
 impl MaybeUtf8 {
-    pub fn new<T: Into<Bytes>>(bytes: T) -> Self {
+    pub fn from_bytes(bytes: impl Into<Bytes>) -> Self {
         Self::from(bytes.into())
+    }
+
+    pub fn from_string(string: impl Into<String>) -> Self {
+        Self::from(string.into())
+    }
+}
+
+impl From<&'static [u8]> for MaybeUtf8 {
+    fn from(value: &'static [u8]) -> Self {
+        Self::from_bytes(value)
+    }
+}
+
+impl From<Vec<u8>> for MaybeUtf8 {
+    fn from(value: Vec<u8>) -> Self {
+        Self::from_bytes(value)
     }
 }
 
@@ -43,6 +61,14 @@ impl From<&'static str> for MaybeUtf8 {
     }
 }
 
+impl FromStr for MaybeUtf8 {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::from_string(s))
+    }
+}
+
 impl MaybeUtf8 {
     pub fn is_utf8(&self) -> bool {
         self.is_utf8
@@ -52,7 +78,7 @@ impl MaybeUtf8 {
         &self.bytes
     }
 
-    pub fn try_as_str(&self) -> Option<&str> {
+    pub fn as_str(&self) -> Option<&str> {
         // SAFETY: UTF-8 validity is checked on construction
         self.is_utf8
             .then(|| unsafe { str::from_utf8_unchecked(&self.bytes) })
@@ -63,7 +89,7 @@ impl Hash for MaybeUtf8 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Produce the same hash as `&[u8]` or `&str`;
         // `impl Hash for str` adds a domain-separation postfix so its routine is separate.
-        match self.try_as_str() {
+        match self.as_str() {
             Some(s) => s.hash(state),
             None => self.bytes.hash(state),
         }
@@ -97,7 +123,13 @@ impl Ord for MaybeUtf8 {
 
 impl PartialEq<str> for MaybeUtf8 {
     fn eq(&self, other: &str) -> bool {
-        self.try_as_str().is_some_and(|s| s == other)
+        self.as_str().is_some_and(|s| s == other)
+    }
+}
+
+impl PartialEq<&str> for MaybeUtf8 {
+    fn eq(&self, other: &&str) -> bool {
+        *self == **other
     }
 }
 
@@ -107,9 +139,15 @@ impl PartialEq<[u8]> for MaybeUtf8 {
     }
 }
 
+impl PartialEq<&[u8]> for MaybeUtf8 {
+    fn eq(&self, other: &&[u8]) -> bool {
+        *self == **other
+    }
+}
+
 impl Debug for MaybeUtf8 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self.try_as_str() {
+        match self.as_str() {
             Some(s) => Debug::fmt(s, f),
             None => write!(f, "\"{}\"", self.bytes.escape_ascii()),
         }
@@ -119,5 +157,152 @@ impl Debug for MaybeUtf8 {
 impl hashbrown::Equivalent<MaybeUtf8> for str {
     fn equivalent(&self, key: &MaybeUtf8) -> bool {
         key == self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MaybeUtf8;
+    use std::hash::{BuildHasher, RandomState};
+
+    #[test]
+    fn is_utf8() {
+        let s = "Hello, world!";
+        let debug = format!("{s:?}");
+
+        let val1 = MaybeUtf8::from(s);
+
+        assert!(val1.is_utf8());
+
+        assert_eq!(val1, s);
+        assert_eq!(val1.as_str(), Some(s));
+
+        assert_eq!(val1, val1);
+
+        assert_eq!(format!("{val1:?}"), debug);
+
+        let val2 = MaybeUtf8::from(s.to_string());
+
+        assert!(val2.is_utf8());
+
+        assert_eq!(val2, s);
+        assert_eq!(val2.as_str(), Some(s));
+
+        assert_eq!(val1, val2);
+        assert_eq!(val2, val2);
+
+        assert_eq!(format!("{val2:?}"), debug);
+
+        let val3 = MaybeUtf8::from_string(s);
+        assert!(val3.is_utf8());
+
+        assert_eq!(val3, s);
+        assert_eq!(val3.as_str(), Some(s));
+
+        assert_eq!(val1, val3);
+        assert_eq!(val2, val3);
+        assert_eq!(val3, val3);
+
+        assert_eq!(format!("{val3:?}"), debug);
+
+        let Ok(val4) = s.parse::<MaybeUtf8>();
+
+        assert!(val4.is_utf8());
+
+        assert_eq!(val4, s);
+        assert_eq!(val4.as_str(), Some(s));
+
+        assert_eq!(val1, val4);
+        assert_eq!(val2, val4);
+        assert_eq!(val3, val4);
+        assert_eq!(val4, val4);
+
+        assert_eq!(format!("{val4:?}"), debug);
+    }
+
+    #[test]
+    fn is_not_utf8() {
+        let bytes: &'static [u8] = &[0xFFu8; 16];
+        let debug = format!("\"{}\"", bytes.escape_ascii());
+
+        let val1 = MaybeUtf8::from(bytes);
+
+        assert!(!val1.is_utf8());
+
+        assert_eq!(val1, bytes);
+        assert_eq!(val1.as_str(), None);
+        assert_eq!(val1.as_bytes(), bytes);
+
+        assert_eq!(val1, val1);
+
+        assert_eq!(format!("{val1:?}"), debug);
+
+        let val2 = MaybeUtf8::from(bytes.to_vec());
+
+        assert!(!val2.is_utf8());
+
+        assert_eq!(val2, bytes);
+        assert_eq!(val2.as_str(), None);
+        assert_eq!(val2.as_bytes(), bytes);
+
+        assert_eq!(val1, val2);
+        assert_eq!(val2, val2);
+
+        assert_eq!(format!("{val2:?}"), debug);
+
+        let val3 = MaybeUtf8::from_bytes(bytes);
+
+        assert!(!val3.is_utf8());
+
+        assert_eq!(val3, bytes);
+        assert_eq!(val3.as_str(), None);
+        assert_eq!(val3.as_bytes(), bytes);
+
+        assert_eq!(val1, val3);
+        assert_eq!(val2, val3);
+        assert_eq!(val3, val3);
+
+        assert_eq!(format!("{val3:?}"), debug);
+    }
+
+    #[test]
+    fn equivalent_hashes_utf8() {
+        let hasher = RandomState::new();
+
+        let s = "Hello, world!";
+
+        assert_eq!(hasher.hash_one(s), hasher.hash_one(MaybeUtf8::from(s)));
+        assert_eq!(
+            hasher.hash_one(s),
+            hasher.hash_one(MaybeUtf8::from(s.to_string()))
+        );
+        assert_eq!(
+            hasher.hash_one(s),
+            hasher.hash_one(MaybeUtf8::from_string(s))
+        );
+        assert_eq!(
+            hasher.hash_one(s),
+            hasher.hash_one(s.parse::<MaybeUtf8>().unwrap())
+        );
+    }
+
+    #[test]
+    fn equivalent_hashes_not_utf8() {
+        let hasher = RandomState::new();
+
+        let bytes: &'static [u8] = &[0xC0; 32];
+
+        assert_eq!(
+            hasher.hash_one(bytes),
+            hasher.hash_one(MaybeUtf8::from(bytes))
+        );
+        assert_eq!(
+            hasher.hash_one(bytes),
+            hasher.hash_one(MaybeUtf8::from(bytes.to_vec()))
+        );
+        assert_eq!(
+            hasher.hash_one(bytes),
+            hasher.hash_one(MaybeUtf8::from_bytes(bytes))
+        );
     }
 }

--- a/src/native/string.rs
+++ b/src/native/string.rs
@@ -1,0 +1,98 @@
+use std::cmp::Ordering;
+use std::fmt::{Debug, Formatter};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct MaybeUtf8(Repr);
+
+#[derive(Clone, PartialEq, Eq)]
+enum Repr {
+    Utf8(Arc<str>),
+    NotUtf8(Arc<[u8]>),
+}
+
+impl From<&[u8]> for MaybeUtf8 {
+    fn from(value: &[u8]) -> Self {
+        Self(
+            str::from_utf8(value)
+                .map_or_else(|_| Repr::NotUtf8(value.into()), |s| Repr::Utf8(s.into())),
+        )
+    }
+}
+
+impl MaybeUtf8 {
+    pub fn as_bytes(&self) -> &[u8] {
+        match &self.0 {
+            Repr::Utf8(s) => s.as_bytes(),
+            Repr::NotUtf8(s) => s,
+        }
+    }
+
+    pub fn try_as_str(&self) -> Option<&str> {
+        // The invariants of the type guarantee that we don't need to re-validate here
+        match &self.0 {
+            Repr::Utf8(s) => Some(s),
+            Repr::NotUtf8(_) => None,
+        }
+    }
+}
+
+impl Hash for MaybeUtf8 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Produce the same hash as `&[u8]` or `&str`;
+        // `impl Hash for str` adds a domain-separation postfix so its routine is separate.
+        match &self.0 {
+            Repr::Utf8(s) => s.hash(state),
+            Repr::NotUtf8(s) => s.hash(state),
+        }
+    }
+}
+
+/// Compares lexicographically regardless of UTF-8-ness.
+impl PartialOrd for MaybeUtf8 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.as_bytes().cmp(other.as_bytes()))
+    }
+}
+
+impl PartialOrd<str> for MaybeUtf8 {
+    fn partial_cmp(&self, other: &str) -> Option<Ordering> {
+        Some(self.as_bytes().cmp(other.as_bytes()))
+    }
+}
+
+impl PartialOrd<[u8]> for MaybeUtf8 {
+    fn partial_cmp(&self, other: &[u8]) -> Option<Ordering> {
+        Some(self.as_bytes().cmp(other))
+    }
+}
+
+impl Ord for MaybeUtf8 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_bytes().cmp(other.as_bytes())
+    }
+}
+
+impl PartialEq<str> for MaybeUtf8 {
+    fn eq(&self, other: &str) -> bool {
+        self.try_as_str().is_some_and(|s| s == other)
+    }
+}
+
+impl PartialEq<[u8]> for MaybeUtf8 {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.as_bytes().eq(other)
+    }
+}
+
+impl Debug for MaybeUtf8 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Repr::Utf8(s) => Debug::fmt(s, f),
+            Repr::NotUtf8(s) => {
+                write!(f, "\"{}\"", s.escape_ascii())
+            }
+        }
+    }
+}

--- a/src/native/string.rs
+++ b/src/native/string.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use std::cmp::Ordering;
 use std::convert::Infallible;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
@@ -154,6 +154,25 @@ impl Debug for MaybeUtf8 {
     }
 }
 
+impl Display for MaybeUtf8 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.as_str() {
+            Some(s) => Display::fmt(s, f),
+            None => {
+                for chunk in self.bytes.utf8_chunks() {
+                    write!(f, "{}", chunk.valid())?;
+
+                    for b in chunk.invalid() {
+                        write!(f, "{}", b.escape_ascii())?;
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
 impl hashbrown::Equivalent<MaybeUtf8> for str {
     fn equivalent(&self, key: &MaybeUtf8) -> bool {
         key == self
@@ -180,6 +199,7 @@ mod tests {
         assert_eq!(val1, val1);
 
         assert_eq!(format!("{val1:?}"), debug);
+        assert_eq!(val1.to_string(), s);
 
         let val2 = MaybeUtf8::from(s.to_string());
 
@@ -192,6 +212,7 @@ mod tests {
         assert_eq!(val2, val2);
 
         assert_eq!(format!("{val2:?}"), debug);
+        assert_eq!(val2.to_string(), s);
 
         let val3 = MaybeUtf8::from_string(s);
         assert!(val3.is_utf8());
@@ -204,6 +225,7 @@ mod tests {
         assert_eq!(val3, val3);
 
         assert_eq!(format!("{val3:?}"), debug);
+        assert_eq!(val3.to_string(), s);
 
         let Ok(val4) = s.parse::<MaybeUtf8>();
 
@@ -218,6 +240,7 @@ mod tests {
         assert_eq!(val4, val4);
 
         assert_eq!(format!("{val4:?}"), debug);
+        assert_eq!(val4.to_string(), s);
     }
 
     #[test]
@@ -236,6 +259,7 @@ mod tests {
         assert_eq!(val1, val1);
 
         assert_eq!(format!("{val1:?}"), debug);
+        assert_eq!(val1.to_string(), bytes.escape_ascii().to_string());
 
         let val2 = MaybeUtf8::from(bytes.to_vec());
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -5,7 +5,7 @@ use tracing::Instrument;
 use url::Url;
 
 use crate::{
-    Client,
+    Client, Compression,
     error::{Error, Result},
     formats,
     headers::with_request_headers,
@@ -15,7 +15,7 @@ use crate::{
     sql::{Bind, SqlBuilder, ser},
 };
 
-pub use crate::cursors::{BytesCursor, RowCursor};
+pub use crate::cursors::{BytesCursor, NativeCursor, RowCursor};
 use crate::headers::with_authentication;
 use crate::settings;
 
@@ -170,6 +170,17 @@ impl Query {
 
         let response = self.do_execute(Some(format))?;
         Ok(BytesCursor::new(response, span.exit()))
+    }
+
+    pub fn fetch_native(mut self) -> Result<NativeCursor> {
+        let span = self.make_span(Some("Native")).entered();
+
+        // FIXME: use HTTP body compression instead of block-level compression
+        self.client = self.client.with_compression(Compression::None);
+
+        let response = self.do_execute(Some("Native"))?;
+
+        Ok(NativeCursor::new(response, span.exit()))
     }
 
     pub(crate) fn make_span(&self, response_format: Option<&str>) -> tracing::Span {

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -1,12 +1,19 @@
 use crate::get_client;
 
 #[tokio::test]
-async fn fixed_width_types() {
+async fn mixed_types() {
     let client = get_client();
 
-    let mut cursor = client.query(
-        "SELECT number, leftPad(toString(number), number, '.') text FROM system.numbers LIMIT 10"
-    )
+    let mut cursor = client
+        .query(
+            "SELECT
+            number,
+            leftPad(toString(number), number, '.') AS text,
+            number % 2 == 0 ?? number : NULL AS nullable_number,
+            number %2 != 0 ?? text : NULL AS nullable_text
+        FROM system.numbers
+        LIMIT 10",
+        )
         .fetch_native()
         .unwrap();
 
@@ -14,7 +21,7 @@ async fn fixed_width_types() {
 
     assert_eq!(block.num_rows(), 10);
 
-    assert_eq!(block.columns().len(), 2);
+    assert_eq!(block.columns().len(), 4);
 
     assert_eq!(block[0].name(), "number");
 
@@ -31,5 +38,37 @@ async fn fixed_width_types() {
     for (text, row) in text_iter.by_ref().zip(0u64..10) {
         let text = text.unwrap();
         assert_eq!(text.len() as u64, row, "incorrect text: {text:?}");
+    }
+
+    assert!(text_iter.next().is_none());
+
+    let mut nullable_number_iter = block["nullable_number"].iter::<Option<u64>>().unwrap();
+
+    for (opt_number, row) in nullable_number_iter.by_ref().zip(0u64..10) {
+        let opt_number = opt_number.unwrap();
+
+        if row % 2 == 0 {
+            assert_eq!(opt_number, Some(row));
+        } else {
+            assert_eq!(opt_number, None);
+        }
+    }
+
+    assert!(nullable_number_iter.next().is_none());
+
+    let mut nullable_text_iter = block["nullable_text"].iter::<Option<&str>>().unwrap();
+
+    for (opt_text, row) in nullable_text_iter.by_ref().zip(0u64..10) {
+        let opt_text = opt_text.unwrap();
+
+        if row % 2 != 0 {
+            assert_eq!(
+                opt_text.unwrap().len() as u64,
+                row,
+                "incorrect nullable text: {opt_text:?}"
+            );
+        } else {
+            assert_eq!(opt_text, None);
+        }
     }
 }

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -2,9 +2,33 @@ use crate::get_client;
 use std::collections::HashMap;
 
 #[tokio::test]
-async fn mixed_types() {
-    const NUM_ROWS: u64 = 10;
+async fn mixed_types_empty() {
+    mixed_types(0).await
+}
 
+#[tokio::test]
+async fn mixed_types_10() {
+    mixed_types(10).await
+}
+
+#[tokio::test]
+async fn mixed_types_100() {
+    mixed_types(100).await
+}
+
+#[tokio::test]
+async fn mixed_types_1000() {
+    mixed_types(1000).await
+}
+
+// NOTE: requires >50GiB RAM on the server, likely because all the strings have to live in memory
+#[tokio::test]
+#[ignore]
+async fn mixed_types_10000() {
+    mixed_types(10000).await
+}
+
+async fn mixed_types(num_rows: u64) {
     let client = get_client();
 
     let mut cursor = client
@@ -25,13 +49,19 @@ async fn mixed_types() {
         FROM system.numbers
         LIMIT {limit:UInt64}",
         )
-        .param("limit", NUM_ROWS)
+        .param("limit", num_rows)
         .fetch_native()
         .unwrap();
 
-    let block = cursor.next().await.unwrap().expect("expected one block");
+    let Some(block) = cursor.next().await.unwrap() else {
+        assert_eq!(
+            num_rows, 0,
+            "num_rows is nonzero but cursor returned no blocks"
+        );
+        return;
+    };
 
-    assert_eq!(block.num_rows() as u64, NUM_ROWS);
+    assert_eq!(block.num_rows() as u64, num_rows);
 
     assert_eq!(block.columns().len(), 12);
 
@@ -39,7 +69,12 @@ async fn mixed_types() {
 
     let mut number_iter = block["number"].iter::<u64>().unwrap();
 
-    for (number, row) in number_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        number_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (number, row) in number_iter.by_ref().zip(0u64..num_rows) {
         assert_eq!(number.unwrap(), row);
     }
 
@@ -47,7 +82,12 @@ async fn mixed_types() {
 
     let mut text_iter = block["text"].iter::<&str>().unwrap();
 
-    for (text, row) in text_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        text_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (text, row) in text_iter.by_ref().zip(0u64..num_rows) {
         let text = text.unwrap();
 
         assert_eq!(text.len() as u64, row);
@@ -61,7 +101,12 @@ async fn mixed_types() {
 
     let mut nullable_number_iter = block["nullable_number"].iter::<Option<u64>>().unwrap();
 
-    for (opt_number, row) in nullable_number_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        nullable_number_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (opt_number, row) in nullable_number_iter.by_ref().zip(0u64..num_rows) {
         let opt_number = opt_number.unwrap();
 
         if row % 2 == 0 {
@@ -75,7 +120,12 @@ async fn mixed_types() {
 
     let mut nullable_text_iter = block["nullable_text"].iter::<Option<&str>>().unwrap();
 
-    for (opt_text, row) in nullable_text_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        nullable_text_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (opt_text, row) in nullable_text_iter.by_ref().zip(0u64..num_rows) {
         let opt_text = opt_text.unwrap();
 
         if row % 2 != 0 {
@@ -93,7 +143,12 @@ async fn mixed_types() {
 
     let mut tuple_iter = block["number_text_tuple"].iter::<(u64, &str)>().unwrap();
 
-    for (tuple, row) in tuple_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        tuple_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (tuple, row) in tuple_iter.by_ref().zip(0u64..num_rows) {
         let (number, text) = tuple.unwrap();
 
         assert_eq!(number, row);
@@ -110,7 +165,12 @@ async fn mixed_types() {
         .iter::<(Option<u64>, Option<&str>)>()
         .unwrap();
 
-    for (tuple, row) in nullable_tuple_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        nullable_tuple_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (tuple, row) in nullable_tuple_iter.by_ref().zip(0u64..num_rows) {
         let (opt_number, opt_text) = tuple.unwrap();
 
         if row % 2 == 0 {
@@ -132,7 +192,12 @@ async fn mixed_types() {
 
     let mut number_array_iter = block["number_array"].iter::<Vec<u64>>().unwrap();
 
-    for (number_array, row) in number_array_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        number_array_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (number_array, row) in number_array_iter.by_ref().zip(0u64..num_rows) {
         let number_array = number_array.unwrap();
 
         assert_eq!(number_array.len() as u64, row);
@@ -147,7 +212,12 @@ async fn mixed_types() {
 
     let mut text_array_iter = block["text_array"].iter::<Vec<&str>>().unwrap();
 
-    for (text_array, row) in text_array_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        text_array_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (text_array, row) in text_array_iter.by_ref().zip(0u64..num_rows) {
         let text_array = text_array.unwrap();
 
         assert_eq!(text_array.len() as u64, row);
@@ -163,7 +233,12 @@ async fn mixed_types() {
         .iter::<HashMap<u64, String>>()
         .unwrap();
 
-    for (map, row) in map_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        map_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (map, row) in map_iter.by_ref().zip(0u64..num_rows) {
         let map = map.unwrap();
 
         assert_eq!(map.len() as u64, row);
@@ -178,7 +253,12 @@ async fn mixed_types() {
     // Should be identical to `text` column
     let mut lc_text_iter = block["low_cardinality_text"].iter::<&str>().unwrap();
 
-    for (text, row) in lc_text_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        lc_text_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (text, row) in lc_text_iter.by_ref().zip(0u64..num_rows) {
         let text = text.unwrap();
 
         assert_eq!(text.len() as u64, row);
@@ -195,7 +275,12 @@ async fn mixed_types() {
         .iter::<Option<&str>>()
         .unwrap();
 
-    for (opt_text, row) in lc_nullable_text_iter.by_ref().zip(0u64..NUM_ROWS) {
+    assert_eq!(
+        lc_nullable_text_iter.size_hint(),
+        (num_rows as usize, Some(num_rows as usize))
+    );
+
+    for (opt_text, row) in lc_nullable_text_iter.by_ref().zip(0u64..num_rows) {
         let opt_text = opt_text.unwrap();
 
         if row % 2 != 0 {

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -24,8 +24,8 @@ async fn mixed_types_1000() {
 }
 
 // NOTE: requires >50GiB RAM on the server, likely because all the strings have to live in memory
-#[tokio::test]
 #[ignore]
+#[tokio::test]
 async fn mixed_types_10000() {
     mixed_types(10000).await
 }
@@ -317,6 +317,8 @@ async fn empty_arrays() {
         "LowCardinality(Nullable(String))",
         "Tuple(UInt64, String, String)",
         "Nullable(Tuple(UInt64, String, String))",
+        "Map(UInt64, String)",
+        "Map(LowCardinality(UInt64), String)",
     ];
 
     let mut query = "SELECT \n".to_string();
@@ -359,4 +361,65 @@ async fn empty_arrays() {
     assert_array_empty::<Option<String>>(&block[7]);
     assert_array_empty::<(u64, String, String)>(&block[8]);
     assert_array_empty::<Option<(u64, String, String)>>(&block[9]);
+    assert_array_empty::<HashMap<u64, String>>(&block[10]);
+    assert_array_empty::<HashMap<u64, String>>(&block[11]);
+}
+
+async fn nested_arrays(num_rows: usize) {
+    let client = get_client();
+
+    let mut cursor = client.query(
+        "SELECT
+            arrayMap(x -> arrayEnumerate(arrayWithConstant(x, x)), arrayEnumerate(arrayWithConstant(number, number))) AS nested_number_array,
+            arrayMap(arr -> mapFromArrays(arr, arrayMap(x -> toString(x), arr)), nested_number_array) AS array_of_maps,
+            arrayMap(x -> toLowCardinality(x), arrayEnumerate(arrayWithConstant(number, number))) AS lc_array
+        FROM system.numbers
+        LIMIT {limit:UInt64}"
+    )
+        .param("limit", num_rows)
+        .fetch_native()
+        .unwrap();
+
+    let Some(block) = cursor.next().await.unwrap() else {
+        assert_eq!(
+            num_rows, 0,
+            "num_rows is nonzero but cursor returned no blocks"
+        );
+        return;
+    };
+
+    let mut nested_number_iter = block["nested_number_array"]
+        .iter::<Vec<Vec<u32>>>()
+        .unwrap();
+
+    for (nested_array, row) in nested_number_iter.by_ref().zip(0..num_rows) {
+        let nested_array = nested_array.unwrap();
+
+        assert_eq!(nested_array.len(), row);
+
+        for (array, i) in nested_array.iter().zip(1..=row) {
+            assert_eq!(*array, (1..=i as u32).collect::<Vec<_>>());
+        }
+    }
+}
+
+#[tokio::test]
+async fn nested_arrays_empty() {
+    nested_arrays(0).await;
+}
+
+#[tokio::test]
+async fn nested_arrays_10() {
+    nested_arrays(10).await;
+}
+
+#[tokio::test]
+async fn nested_arrays_100() {
+    nested_arrays(100).await;
+}
+
+#[ignore] // requires a lot of memory
+#[tokio::test]
+async fn nested_arrays_1000() {
+    nested_arrays(1000).await;
 }

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -1,7 +1,10 @@
 use crate::get_client;
+use std::collections::HashMap;
 
 #[tokio::test]
 async fn mixed_types() {
+    const NUM_ROWS: u64 = 10;
+
     let client = get_client();
 
     let mut cursor = client
@@ -11,25 +14,30 @@ async fn mixed_types() {
             leftPad(toString(number), number, '.') AS text,
             number % 2 == 0 ?? number : NULL AS nullable_number,
             number % 2 != 0 ?? text : NULL AS nullable_text,
+            tuple(number, text) AS number_text_tuple,
+            tuple(nullable_number, nullable_text) AS nullable_tuple,
             arrayMap(x -> toUInt64(x), arrayEnumerate(arrayWithConstant(number, toUInt64(0)))) AS number_array,
-            arrayMap(x -> rightPad(toString(x), x, '-'), number_array) AS text_array
+            arrayMap(x -> rightPad(toString(x), x, '-'), number_array) AS text_array,
+            arrayZip(number_array, text_array) AS number_text_tuple_array,
+            mapFromArrays(number_array, text_array) AS number_to_text_map
         FROM system.numbers
-        LIMIT 10",
+        LIMIT {limit:UInt64}",
         )
+        .param("limit", NUM_ROWS)
         .fetch_native()
         .unwrap();
 
     let block = cursor.next().await.unwrap().expect("expected one block");
 
-    assert_eq!(block.num_rows(), 10);
+    assert_eq!(block.num_rows() as u64, NUM_ROWS);
 
-    assert_eq!(block.columns().len(), 6);
+    assert_eq!(block.columns().len(), 10);
 
     assert_eq!(block[0].name(), "number");
 
     let mut number_iter = block["number"].iter::<u64>().unwrap();
 
-    for (number, row) in number_iter.by_ref().zip(0u64..10) {
+    for (number, row) in number_iter.by_ref().zip(0u64..NUM_ROWS) {
         assert_eq!(number.unwrap(), row);
     }
 
@@ -37,7 +45,7 @@ async fn mixed_types() {
 
     let mut text_iter = block["text"].iter::<&str>().unwrap();
 
-    for (text, row) in text_iter.by_ref().zip(0u64..10) {
+    for (text, row) in text_iter.by_ref().zip(0u64..NUM_ROWS) {
         let text = text.unwrap();
 
         assert_eq!(text.len() as u64, row);
@@ -51,7 +59,7 @@ async fn mixed_types() {
 
     let mut nullable_number_iter = block["nullable_number"].iter::<Option<u64>>().unwrap();
 
-    for (opt_number, row) in nullable_number_iter.by_ref().zip(0u64..10) {
+    for (opt_number, row) in nullable_number_iter.by_ref().zip(0u64..NUM_ROWS) {
         let opt_number = opt_number.unwrap();
 
         if row % 2 == 0 {
@@ -65,8 +73,49 @@ async fn mixed_types() {
 
     let mut nullable_text_iter = block["nullable_text"].iter::<Option<&str>>().unwrap();
 
-    for (opt_text, row) in nullable_text_iter.by_ref().zip(0u64..10) {
+    for (opt_text, row) in nullable_text_iter.by_ref().zip(0u64..NUM_ROWS) {
         let opt_text = opt_text.unwrap();
+
+        if row % 2 != 0 {
+            assert_eq!(
+                opt_text.unwrap().len() as u64,
+                row,
+                "incorrect nullable text: {opt_text:?}"
+            );
+        } else {
+            assert_eq!(opt_text, None);
+        }
+    }
+
+    assert!(nullable_text_iter.next().is_none());
+
+    let mut tuple_iter = block["number_text_tuple"].iter::<(u64, &str)>().unwrap();
+
+    for (tuple, row) in tuple_iter.by_ref().zip(0u64..NUM_ROWS) {
+        let (number, text) = tuple.unwrap();
+
+        assert_eq!(number, row);
+        assert_eq!(text.len() as u64, row);
+
+        if row > 0 {
+            assert_eq!(text, format!("{row:.>width$}", width = row as usize));
+        }
+    }
+
+    assert!(tuple_iter.next().is_none());
+
+    let mut nullable_tuple_iter = block["nullable_tuple"]
+        .iter::<(Option<u64>, Option<&str>)>()
+        .unwrap();
+
+    for (tuple, row) in nullable_tuple_iter.by_ref().zip(0u64..NUM_ROWS) {
+        let (opt_number, opt_text) = tuple.unwrap();
+
+        if row % 2 == 0 {
+            assert_eq!(opt_number, Some(row));
+        } else {
+            assert_eq!(opt_number, None);
+        }
 
         if row % 2 != 0 {
             assert_eq!(
@@ -81,7 +130,7 @@ async fn mixed_types() {
 
     let mut number_array_iter = block["number_array"].iter::<Vec<u64>>().unwrap();
 
-    for (number_array, row) in number_array_iter.by_ref().zip(0u64..10) {
+    for (number_array, row) in number_array_iter.by_ref().zip(0u64..NUM_ROWS) {
         let number_array = number_array.unwrap();
 
         assert_eq!(number_array.len() as u64, row);
@@ -96,7 +145,7 @@ async fn mixed_types() {
 
     let mut text_array_iter = block["text_array"].iter::<Vec<&str>>().unwrap();
 
-    for (text_array, row) in text_array_iter.by_ref().zip(0u64..10) {
+    for (text_array, row) in text_array_iter.by_ref().zip(0u64..NUM_ROWS) {
         let text_array = text_array.unwrap();
 
         assert_eq!(text_array.len() as u64, row);
@@ -105,4 +154,22 @@ async fn mixed_types() {
             assert_eq!(*text, format!("{len:-<width$}", width = len as usize));
         }
     }
+
+    assert!(text_array_iter.next().is_none());
+
+    let mut map_iter = block["number_to_text_map"]
+        .iter::<HashMap<u64, String>>()
+        .unwrap();
+
+    for (map, row) in map_iter.by_ref().zip(0u64..NUM_ROWS) {
+        let map = map.unwrap();
+
+        assert_eq!(map.len() as u64, row);
+
+        for i in 1..=row {
+            assert_eq!(map[&i], format!("{i:-<width$}", width = i as usize))
+        }
+    }
+
+    assert!(map_iter.next().is_none());
 }

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -10,9 +10,9 @@ async fn mixed_types() {
             number,
             leftPad(toString(number), number, '.') AS text,
             number % 2 == 0 ?? number : NULL AS nullable_number,
-            number %2 != 0 ?? text : NULL AS nullable_text,
-            arrayMap(x -> toUInt64(x), arrayEnumerate(arrayWithConstant(number, toUInt64(0)))) AS number_array
-            -- arrayMap(x -> rightPad(toString(number), number, '-'), number_array) AS text_array
+            number % 2 != 0 ?? text : NULL AS nullable_text,
+            arrayMap(x -> toUInt64(x), arrayEnumerate(arrayWithConstant(number, toUInt64(0)))) AS number_array,
+            arrayMap(x -> rightPad(toString(x), x, '-'), number_array) AS text_array
         FROM system.numbers
         LIMIT 10",
         )
@@ -23,7 +23,7 @@ async fn mixed_types() {
 
     assert_eq!(block.num_rows(), 10);
 
-    assert_eq!(block.columns().len(), 5);
+    assert_eq!(block.columns().len(), 6);
 
     assert_eq!(block[0].name(), "number");
 
@@ -39,7 +39,12 @@ async fn mixed_types() {
 
     for (text, row) in text_iter.by_ref().zip(0u64..10) {
         let text = text.unwrap();
-        assert_eq!(text.len() as u64, row, "incorrect text: {text:?}");
+
+        assert_eq!(text.len() as u64, row);
+
+        if row > 0 {
+            assert_eq!(text, format!("{row:.>width$}", width = row as usize));
+        }
     }
 
     assert!(text_iter.next().is_none());
@@ -82,8 +87,22 @@ async fn mixed_types() {
         assert_eq!(number_array.len() as u64, row);
 
         assert!(
-            number_array.iter().copied().eq(0u64..row),
-            "invalid number_array: {number_array:?}"
+            number_array.iter().copied().eq(1u64..=row),
+            "invalid number_array for row #{row}: {number_array:?}"
         );
+    }
+
+    assert!(number_array_iter.next().is_none());
+
+    let mut text_array_iter = block["text_array"].iter::<Vec<&str>>().unwrap();
+
+    for (text_array, row) in text_array_iter.by_ref().zip(0u64..10) {
+        let text_array = text_array.unwrap();
+
+        assert_eq!(text_array.len() as u64, row);
+
+        for (text, len) in text_array.iter().zip(1..=row) {
+            assert_eq!(*text, format!("{len:-<width$}", width = len as usize));
+        }
     }
 }

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -1,0 +1,35 @@
+use crate::get_client;
+
+#[tokio::test]
+async fn fixed_width_types() {
+    let client = get_client();
+
+    let mut cursor = client.query(
+        "SELECT number, leftPad(toString(number), number, '.') text FROM system.numbers LIMIT 10"
+    )
+        .fetch_native()
+        .unwrap();
+
+    let block = cursor.next().await.unwrap().expect("expected one block");
+
+    assert_eq!(block.num_rows(), 10);
+
+    assert_eq!(block.columns().len(), 2);
+
+    assert_eq!(block[0].name(), "number");
+
+    let mut number_iter = block["number"].iter::<u64>().unwrap();
+
+    for (number, row) in number_iter.by_ref().zip(0u64..10) {
+        assert_eq!(number.unwrap(), row);
+    }
+
+    assert!(number_iter.next().is_none());
+
+    let mut text_iter = block["text"].iter::<&str>().unwrap();
+
+    for (text, row) in text_iter.by_ref().zip(0u64..10) {
+        let text = text.unwrap();
+        assert_eq!(text.len() as u64, row, "incorrect text: {text:?}");
+    }
+}

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -10,7 +10,9 @@ async fn mixed_types() {
             number,
             leftPad(toString(number), number, '.') AS text,
             number % 2 == 0 ?? number : NULL AS nullable_number,
-            number %2 != 0 ?? text : NULL AS nullable_text
+            number %2 != 0 ?? text : NULL AS nullable_text,
+            arrayMap(x -> toUInt64(x), arrayEnumerate(arrayWithConstant(number, toUInt64(0)))) AS number_array
+            -- arrayMap(x -> rightPad(toString(number), number, '-'), number_array) AS text_array
         FROM system.numbers
         LIMIT 10",
         )
@@ -21,7 +23,7 @@ async fn mixed_types() {
 
     assert_eq!(block.num_rows(), 10);
 
-    assert_eq!(block.columns().len(), 4);
+    assert_eq!(block.columns().len(), 5);
 
     assert_eq!(block[0].name(), "number");
 
@@ -70,5 +72,18 @@ async fn mixed_types() {
         } else {
             assert_eq!(opt_text, None);
         }
+    }
+
+    let mut number_array_iter = block["number_array"].iter::<Vec<u64>>().unwrap();
+
+    for (number_array, row) in number_array_iter.by_ref().zip(0u64..10) {
+        let number_array = number_array.unwrap();
+
+        assert_eq!(number_array.len() as u64, row);
+
+        assert!(
+            number_array.iter().copied().eq(0u64..row),
+            "invalid number_array: {number_array:?}"
+        );
     }
 }

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -388,11 +388,11 @@ async fn nested_arrays(num_rows: usize) {
         return;
     };
 
-    let mut nested_number_iter = block["nested_number_array"]
+    let mut nested_array_iter = block["nested_number_array"]
         .iter::<Vec<Vec<u32>>>()
         .unwrap();
 
-    for (nested_array, row) in nested_number_iter.by_ref().zip(0..num_rows) {
+    for (nested_array, row) in nested_array_iter.by_ref().zip(0..num_rows) {
         let nested_array = nested_array.unwrap();
 
         assert_eq!(nested_array.len(), row);
@@ -401,6 +401,39 @@ async fn nested_arrays(num_rows: usize) {
             assert_eq!(*array, (1..=i as u32).collect::<Vec<_>>());
         }
     }
+
+    assert!(nested_array_iter.next().is_none());
+
+    let mut nested_map_iter = block["array_of_maps"]
+        .iter::<Vec<HashMap<u32, String>>>()
+        .unwrap();
+
+    for (nested_map, row) in nested_map_iter.by_ref().zip(0..num_rows) {
+        let nested_map = nested_map.unwrap();
+
+        assert_eq!(nested_map.len(), row);
+
+        for (map, i) in nested_map.iter().zip(1..=row) {
+            assert_eq!(
+                *map,
+                (1..=i as u32)
+                    .map(|i| (i, i.to_string()))
+                    .collect::<HashMap<_, _>>()
+            );
+        }
+    }
+
+    assert!(nested_map_iter.next().is_none());
+
+    let mut lc_array_iter = block["lc_array"].iter::<Vec<u32>>().unwrap();
+
+    for (array, row) in lc_array_iter.by_ref().zip(0..num_rows) {
+        let array = array.unwrap();
+
+        assert_eq!(array, (1..=row as u32).collect::<Vec<_>>());
+    }
+
+    assert!(lc_array_iter.next().is_none());
 }
 
 #[tokio::test]

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -1,5 +1,7 @@
 use crate::get_client;
+use clickhouse::native::{Column, Decode};
 use std::collections::HashMap;
+use std::fmt::Debug;
 
 #[tokio::test]
 async fn mixed_types_empty() {
@@ -334,4 +336,27 @@ async fn empty_arrays() {
     let mut cursor = client.query(&query).fetch_native().unwrap();
 
     let block = cursor.next().await.unwrap().expect("expected one block");
+
+    fn assert_array_empty<'a, T: Decode<'a> + Debug>(col: &'a Column) {
+        let mut iter = col.iter::<Vec<T>>().unwrap();
+
+        let vec = iter.next().expect("expected array").unwrap();
+
+        assert!(vec.is_empty(), "got nonempty array: {vec:?}");
+
+        let next = iter.next();
+
+        assert!(next.is_none(), "unexpected second value: {next:?}");
+    }
+
+    assert_array_empty::<i8>(&block[0]);
+    assert_array_empty::<u64>(&block[1]);
+    assert_array_empty::<String>(&block[2]);
+    assert_array_empty::<Option<i32>>(&block[3]);
+    assert_array_empty::<Option<String>>(&block[4]);
+    assert_array_empty::<u64>(&block[5]);
+    assert_array_empty::<String>(&block[6]);
+    assert_array_empty::<Option<String>>(&block[7]);
+    assert_array_empty::<(u64, String, String)>(&block[8]);
+    assert_array_empty::<Option<(u64, String, String)>>(&block[9]);
 }

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -19,7 +19,9 @@ async fn mixed_types() {
             arrayMap(x -> toUInt64(x), arrayEnumerate(arrayWithConstant(number, toUInt64(0)))) AS number_array,
             arrayMap(x -> rightPad(toString(x), x, '-'), number_array) AS text_array,
             arrayZip(number_array, text_array) AS number_text_tuple_array,
-            mapFromArrays(number_array, text_array) AS number_to_text_map
+            mapFromArrays(number_array, text_array) AS number_to_text_map,
+            toLowCardinality(text) as low_cardinality_text,
+            toLowCardinality(nullable_text) as low_cardinality_nullable
         FROM system.numbers
         LIMIT {limit:UInt64}",
         )
@@ -31,7 +33,7 @@ async fn mixed_types() {
 
     assert_eq!(block.num_rows() as u64, NUM_ROWS);
 
-    assert_eq!(block.columns().len(), 10);
+    assert_eq!(block.columns().len(), 12);
 
     assert_eq!(block[0].name(), "number");
 
@@ -172,4 +174,40 @@ async fn mixed_types() {
     }
 
     assert!(map_iter.next().is_none());
+
+    // Should be identical to `text` column
+    let mut lc_text_iter = block["low_cardinality_text"].iter::<&str>().unwrap();
+
+    for (text, row) in lc_text_iter.by_ref().zip(0u64..NUM_ROWS) {
+        let text = text.unwrap();
+
+        assert_eq!(text.len() as u64, row);
+
+        if row > 0 {
+            assert_eq!(text, format!("{row:.>width$}", width = row as usize));
+        }
+    }
+
+    assert!(lc_text_iter.next().is_none());
+
+    // Should be identical to `nullable_text` column
+    let mut lc_nullable_text_iter = block["low_cardinality_nullable"]
+        .iter::<Option<&str>>()
+        .unwrap();
+
+    for (opt_text, row) in lc_nullable_text_iter.by_ref().zip(0u64..NUM_ROWS) {
+        let opt_text = opt_text.unwrap();
+
+        if row % 2 != 0 {
+            assert_eq!(
+                opt_text.unwrap().len() as u64,
+                row,
+                "incorrect nullable text: {opt_text:?}"
+            );
+        } else {
+            assert_eq!(opt_text, None);
+        }
+    }
+
+    assert!(lc_nullable_text_iter.next().is_none());
 }

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -34,20 +34,20 @@ async fn mixed_types(num_rows: u64) {
     let mut cursor = client
         .query(
             "SELECT
-            number,
-            leftPad(toString(number), number, '.') AS text,
-            number % 2 == 0 ?? number : NULL AS nullable_number,
-            number % 2 != 0 ?? text : NULL AS nullable_text,
-            tuple(number, text) AS number_text_tuple,
-            tuple(nullable_number, nullable_text) AS nullable_tuple,
-            arrayMap(x -> toUInt64(x), arrayEnumerate(arrayWithConstant(number, toUInt64(0)))) AS number_array,
-            arrayMap(x -> rightPad(toString(x), x, '-'), number_array) AS text_array,
-            arrayZip(number_array, text_array) AS number_text_tuple_array,
-            mapFromArrays(number_array, text_array) AS number_to_text_map,
-            toLowCardinality(text) as low_cardinality_text,
-            toLowCardinality(nullable_text) as low_cardinality_nullable
-        FROM system.numbers
-        LIMIT {limit:UInt64}",
+                number,
+                leftPad(toString(number), number, '.') AS text,
+                number % 2 == 0 ?? number : NULL AS nullable_number,
+                number % 2 != 0 ?? text : NULL AS nullable_text,
+                tuple(number, text) AS number_text_tuple,
+                tuple(nullable_number, nullable_text) AS nullable_tuple,
+                arrayMap(x -> toUInt64(x), arrayEnumerate(arrayWithConstant(number, toUInt64(0)))) AS number_array,
+                arrayMap(x -> rightPad(toString(x), x, '-'), number_array) AS text_array,
+                arrayZip(number_array, text_array) AS number_text_tuple_array,
+                mapFromArrays(number_array, text_array) AS number_to_text_map,
+                toLowCardinality(text) as low_cardinality_text,
+                toLowCardinality(nullable_text) as low_cardinality_nullable
+            FROM system.numbers
+            LIMIT {limit:UInt64}",
         )
         .param("limit", num_rows)
         .fetch_native()
@@ -295,4 +295,43 @@ async fn mixed_types(num_rows: u64) {
     }
 
     assert!(lc_nullable_text_iter.next().is_none());
+}
+
+#[tokio::test]
+async fn empty_arrays() {
+    use std::fmt::Write;
+
+    // test decoding empty arrays of various types
+    let client = get_client();
+
+    let types = [
+        "Int8",
+        "UInt64",
+        "String",
+        "Nullable(Int32)",
+        "Nullable(String)",
+        "LowCardinality(UInt64)",
+        "LowCardinality(String)",
+        "LowCardinality(Nullable(String))",
+        "Tuple(UInt64, String, String)",
+        "Nullable(Tuple(UInt64, String, String))",
+    ];
+
+    let mut query = "SELECT \n".to_string();
+
+    let mut comma = false;
+
+    for ty in types {
+        if comma {
+            writeln!(query, ",").unwrap();
+        }
+
+        write!(query, "defaultValueOfTypeName('Array({ty})')").unwrap();
+
+        comma = true;
+    }
+
+    let mut cursor = client.query(&query).fetch_native().unwrap();
+
+    let block = cursor.next().await.unwrap().expect("expected one block");
 }

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -1,6 +1,6 @@
 use crate::get_client;
 use clickhouse::native::{Column, Decode};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 
 #[tokio::test]
@@ -405,7 +405,8 @@ async fn nested_arrays(num_rows: usize) {
     assert!(nested_array_iter.next().is_none());
 
     let mut nested_map_iter = block["array_of_maps"]
-        .iter::<Vec<HashMap<u32, String>>>()
+        // Doubles as coverage for `impl Decode for BTreeMap`
+        .iter::<Vec<BTreeMap<u32, String>>>()
         .unwrap();
 
     for (nested_map, row) in nested_map_iter.by_ref().zip(0..num_rows) {
@@ -418,7 +419,7 @@ async fn nested_arrays(num_rows: usize) {
                 *map,
                 (1..=i as u32)
                     .map(|i| (i, i.to_string()))
-                    .collect::<HashMap<_, _>>()
+                    .collect::<BTreeMap<_, _>>()
             );
         }
     }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -254,6 +254,7 @@ mod compression;
 mod cursor_error;
 mod cursor_stats;
 mod fetch_bytes;
+mod fetch_native;
 mod https_errors;
 mod insert;
 mod insert_formatted;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -264,6 +264,7 @@ mod int128;
 mod int256;
 mod ip;
 mod mock;
+mod native_types;
 mod nested;
 #[cfg(feature = "opentelemetry")]
 mod opentelemetry;

--- a/tests/it/native_types.rs
+++ b/tests/it/native_types.rs
@@ -1,0 +1,105 @@
+macro_rules! test_type {
+    (
+        $(#[$attr:meta])*
+        $fn_name:ident($ty:ty $(, $sqlty:literal)?) {
+            $($sql:literal == $rust:expr),* $(,)?
+        }
+    ) => {
+        $(#[$attr])*
+        #[tokio::test]
+        async fn $fn_name() {
+            let client = $crate::get_client();
+
+            let mut cursor = client
+                .query(concat!(
+                    "SELECT c1 FROM Values ("
+                    $(,"'c1 ", $sqlty, "', ")?
+                    $(, $sql, )","*
+                    ")"
+                ))
+                .fetch_native()
+                .expect("error from `.fetch_native()`");
+
+            let block = cursor.next().await
+                .expect("error from `cursor.next()`")
+                .expect("expected block, got none");
+
+            let mut iter = block["c1"]
+                .iter::<$ty>()
+                .expect("error from `.iter()`");
+
+            $(
+                let expected = $rust;
+
+                let val = iter
+                    .next()
+                    .expect("expected another value, got none")
+                    .unwrap_or_else(|e| panic!("error decoding SQL `{}` as Rust value `{expected:?}`: {e:?}", $sql));
+
+                assert_eq!(val, expected);
+            )*
+
+            if let Some(next) = iter.next() {
+                panic!("unexpected value: {next:?}");
+            }
+        }
+    };
+}
+
+test_type!(test_bool(bool) { "false" == false, "true" == true });
+
+test_type!(test_uint8(u8) { "0" == 0, "1" == 1, "255" == 255 });
+test_type!(test_uint16(u16) { "0" == 0, "1" == 1, "255" == 255, "16384" == 16384, "65535" == 65535 });
+test_type!(test_uint32(u32) {
+    "0" == 0, "1" == 1, "255" == 255, "16384" == 16384, "65535" == 65535,
+    "0xFFFF_FFFF" == 0xFFFF_FFFF,
+});
+test_type!(test_uint64(u64) {
+    "0" == 0, "1" == 1, "255" == 255, "16384" == 16384, "65535" == 65535,
+    "0xFFFF_FFFF" == 0xFFFF_FFFF, "0xFFFF_FFFF_FFFF_FFFF" == 0xFFFF_FFFF_FFFF_FFFF
+});
+
+// Explicit typing is required, otherwise the unsigned values cause an implicit widening
+// to the next larger signed type:
+//
+// `SELECT toTypeName([-1])` => `Array(Int8)`
+// `SELECT toTypeName([-1, 1])` => `Array(Int16)`
+test_type!(test_int8(i8, "Int8") { "-128" == -128, "-1" == -1, "0" == 0, "1" == 1, "127" == 127 });
+test_type!(test_int16(i16, "Int16") {
+    "-32768 AS Int16" == -32768, "-128" == -128, "-1" == -1,
+    "0" == 0, "1" == 1, "255" == 255, "16384" == 16384, "32767" == 32767
+});
+test_type!(test_int32(i32, "Int32") {
+    "-0x8000_0000" == -0x8000_0000, "-32768" == -32768, "-128" == -128, "-1" == -1,
+    "0" == 0, "1" == 1, "255" == 255, "16384" == 16384, "65535" == 65535,
+    "0x7FFF_FFFF" == 0x7FFF_FFFF,
+});
+test_type!(test_int64(i64, "Int64") {
+    "-0x8000_0000_0000_0000" == -0x8000_0000_0000_0000, "-0x8000_0000" == -0x8000_0000,
+    "-32768" == -32768, "-128" == -128, "-1" == -1,
+    "0" == 0, "1" == 1, "255" == 255, "16384" == 16384, "65535" == 65535,
+    "0xFFFF_FFFF" == 0xFFFF_FFFF, "0x7FFF_FFFF_FFFF_FFFF" == 0x7FFF_FFFF_FFFF_FFFF
+});
+
+test_type!(
+    #[allow(clippy::approx_constant)] // we can't be certain the constant for pi is the same
+    test_float32(f32, "Float32") {
+        // ClickHouse rejects the bare literal but allows the cast for some reason
+        "-inf" == f32::NEG_INFINITY, "toFloat32(-3.40282347e+38)" == f32::MIN,
+        "-1.0" == -1.0, "0.0" == 0.0, "toFloat32(1.17549435e-38)" == f32::MIN_POSITIVE,
+        "1.0" == 1.0, "toFloat32(3.14)" == 3.14,
+        "toFloat32(3.40282347e+38)" == f32::MAX, "inf" == f32::INFINITY,
+        // "nan" == f32::NAN, (NaN is never equal to NaN)
+    }
+);
+
+test_type!(
+    #[allow(clippy::approx_constant)] // we can't be certain the constant for pi is the same
+    test_float64(f64, "Float64") {
+        "-inf" == f64::NEG_INFINITY, "-1.7976931348623157e+308" == f64::MIN,
+        "-1.0" == -1.0, "0.0" == 0.0, "2.2250738585072014e-308" == f64::MIN_POSITIVE,
+        "1.0" == 1.0, "3.14" == 3.14,
+        "1.7976931348623157e+308" == f64::MAX, "inf" == f64::INFINITY,
+        // "nan" == f32::NAN, (NaN is never equal to NaN)
+    }
+);

--- a/tests/it/native_types.rs
+++ b/tests/it/native_types.rs
@@ -145,3 +145,16 @@ test_type!(
         "'2606:4700:3108::ac42:28f9'" == "2606:4700:3108::ac42:28f9".parse::<Ipv6Addr>().unwrap(),
     }
 );
+
+#[cfg(feature = "uuid")]
+mod uuid {
+    use uuid::Uuid;
+
+    test_type!(
+        test_uuid(Uuid, "UUID") {
+            "'00000000-0000-0000-0000-000000000000'" == Uuid::from_bytes([0u8; 16]),
+            "'61f0c404-5cb3-11e7-907b-a6006ad3dba0'" == "61f0c404-5cb3-11e7-907b-a6006ad3dba0".parse::<Uuid>().unwrap(),
+            "'67e55044-10b1-426f-9247-bb680e5fe0c8'" == "67e55044-10b1-426f-9247-bb680e5fe0c8".parse::<Uuid>().unwrap(),
+        }
+    );
+}

--- a/tests/it/native_types.rs
+++ b/tests/it/native_types.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
 macro_rules! test_type {
     (
         $(#[$attr:meta])*
@@ -101,5 +103,45 @@ test_type!(
         "1.0" == 1.0, "3.14" == 3.14,
         "1.7976931348623157e+308" == f64::MAX, "inf" == f64::INFINITY,
         // "nan" == f32::NAN, (NaN is never equal to NaN)
+    }
+);
+
+test_type!(
+    test_ipv4(Ipv4Addr, "IPv4") {
+        "'0.0.0.0'" == Ipv4Addr::UNSPECIFIED,
+        "'1.1.1.1'" == Ipv4Addr::new(1, 1, 1, 1),
+        "'127.0.0.1'" == Ipv4Addr::LOCALHOST,
+        "'192.168.2.1'" == Ipv4Addr::new(192, 168, 2, 1),
+        "'255.255.255.0'" == Ipv4Addr::new(255, 255, 255, 0),
+        "'255.255.255.255'" == Ipv4Addr::BROADCAST,
+    }
+);
+
+test_type!(
+    test_ipaddr_from_v4(IpAddr, "IPv4") {
+        "'0.0.0.0'" == Ipv4Addr::UNSPECIFIED,
+        "'1.1.1.1'" == Ipv4Addr::new(1, 1, 1, 1),
+        "'127.0.0.1'" == Ipv4Addr::LOCALHOST,
+        "'192.168.2.1'" == Ipv4Addr::new(192, 168, 2, 1),
+        "'255.255.255.0'" == Ipv4Addr::new(255, 255, 255, 0),
+        "'255.255.255.255'" == Ipv4Addr::BROADCAST,
+    }
+);
+
+test_type!(
+    test_ipv6(Ipv6Addr, "IPv6") {
+        "'::1'" == Ipv6Addr::LOCALHOST,
+        // IPv6 addresses for ClickHouse.com
+        "'2606:4700:3108::ac42:2b07'" == "2606:4700:3108::ac42:2b07".parse::<Ipv6Addr>().unwrap(),
+        "'2606:4700:3108::ac42:28f9'" == "2606:4700:3108::ac42:28f9".parse::<Ipv6Addr>().unwrap(),
+    }
+);
+
+test_type!(
+    test_ipaddr_from_v6(IpAddr, "IPv6") {
+        "'::1'" == Ipv6Addr::LOCALHOST,
+        // IPv6 addresses for ClickHouse.com
+        "'2606:4700:3108::ac42:2b07'" == "2606:4700:3108::ac42:2b07".parse::<Ipv6Addr>().unwrap(),
+        "'2606:4700:3108::ac42:28f9'" == "2606:4700:3108::ac42:28f9".parse::<Ipv6Addr>().unwrap(),
     }
 );


### PR DESCRIPTION
## Summary
Implements the groundwork for reading (and later, writing) `FORMAT Native` data over HTTP.

* Implemented `Query::fetch_native()` returning `NativeCursor` which yields `Block`s.
    * `Block` holds data in columnar format and can be indexed by column name or by ordinal.
    * `Column::iter()` returns an iterator that decodes the column data.
    * All primitive types, `Nullable`, `Tuple`, `Map` and `LowCardinality` are supported and can be decoded into their appropriate Rust types.
    * Zero-copy decoding to `&str`, borrowing from the parent `Block`, is supported.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
