### PR TITLE
fix: replace use of `avg` in `insert_formatted` test

### DIFF
--- a/tests/it/cloud_jwt.rs
+++ b/tests/it/cloud_jwt.rs
@@ -2,6 +2,7 @@ use crate::{get_cloud_url, require_env_var};
 use clickhouse::Client;
 
 #[tokio::test]
+#[ignore] // FIXME(abonander,2026-07-13): staging JWT has apparently expired and still no prod JWT
 async fn test_jwt_auth() {
     check_cloud_test_env!();
     let valid_token = require_env_var("CLICKHOUSE_CLOUD_JWT_ACCESS_TOKEN");

--- a/tests/it/fixtures/.gitattributes
+++ b/tests/it/fixtures/.gitattributes
@@ -1,0 +1,2 @@
+# ClickHouse rejects TSV with CRLF line endings
+*.tsv text eol=lf

--- a/tests/it/fixtures/.gitattributes
+++ b/tests/it/fixtures/.gitattributes
@@ -1,2 +1,2 @@
-# ClickHouse rejects TSV with CRLF line endings
+# ClickHouse rejects TSV with CRLF line endings (when testing on Windows)
 *.tsv text eol=lf

--- a/tests/it/insert_formatted.rs
+++ b/tests/it/insert_formatted.rs
@@ -366,7 +366,7 @@ async fn verify_insert(client: &Client) {
     struct Results {
         min_trip_id: u32,
         max_trip_id: u32,
-        avg_trip_distance: f64,
+        median_trip_distance: f64,
         count: u64,
     }
 
@@ -375,7 +375,7 @@ async fn verify_insert(client: &Client) {
             "SELECT \
                 min(trip_id) min_trip_id, \
                 max(trip_id) max_trip_id, \
-                avg(trip_distance) avg_trip_distance,\
+                median(trip_distance) median_trip_distance,\
                 count(*) count \
             FROM nyc_taxi_trips_small",
         )
@@ -385,6 +385,6 @@ async fn verify_insert(client: &Client) {
 
     assert_eq!(results.min_trip_id, 1199999902);
     assert_eq!(results.max_trip_id, 1200019742);
-    assert_eq!(results.avg_trip_distance, 2.983289997249842);
+    assert_eq!(results.median_trip_distance, 1.7999999523162842);
     assert_eq!(results.count, 1000);
 }

--- a/tests/it/opentelemetry.rs
+++ b/tests/it/opentelemetry.rs
@@ -1,10 +1,10 @@
 use crate::get_client;
 use opentelemetry::Context;
 use opentelemetry::global::BoxedTracer;
-use opentelemetry::trace::{Status, TraceContextExt};
+use opentelemetry::trace::{Status, TraceContextExt, TracerProvider};
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
-use opentelemetry_sdk::trace::{SdkTracerProvider, Span, SpanData, SpanProcessor};
+use opentelemetry_sdk::trace::{SdkTracer, SdkTracerProvider, Span, SpanData, SpanProcessor};
 use std::cell::Cell;
 use std::sync::Once;
 use std::time::Duration;
@@ -161,7 +161,7 @@ thread_local! {
     static LAST_SPAN_DATA: Cell<Option<SpanData>> = const {  Cell::new(None) };
 }
 
-fn get_tracer() -> BoxedTracer {
+fn get_tracer() -> SdkTracer {
     static ONCE: Once = Once::new();
 
     #[derive(Debug)]
@@ -185,17 +185,14 @@ fn get_tracer() -> BoxedTracer {
     }
 
     ONCE.call_once(|| {
-        // These set global statics so we want to ensure this is done,
+        // This sets a global static so we want to ensure this is done,
         // but it only needs to be done once.
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
-
-        let provider = SdkTracerProvider::builder()
-            .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
-            .with_span_processor(LastSpanProcessor)
-            .build();
-
-        opentelemetry::global::set_tracer_provider(provider);
     });
 
-    opentelemetry::global::tracer("clickhouse_test_opentelemetry")
+    SdkTracerProvider::builder()
+        .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
+        .with_span_processor(LastSpanProcessor)
+        .build()
+        .tracer("clickhouse_test_opentelemetry")
 }

--- a/tests/it/opentelemetry.rs
+++ b/tests/it/opentelemetry.rs
@@ -1,6 +1,5 @@
 use crate::get_client;
 use opentelemetry::Context;
-use opentelemetry::global::BoxedTracer;
 use opentelemetry::trace::{Status, TraceContextExt, TracerProvider};
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::propagation::TraceContextPropagator;


### PR DESCRIPTION
## Summary
The result of the `avg()` function in this test changed, apparently due to some difference in query planning that caused values to be averaged in a different order, ending up with a slightly different result:

```
assertion `left == right` failed
  left: 2.9832899959385397
 right: 2.983289997249842
```

In hindsight, asserting the exact result of `avg()` was bound to be fragile anyway. All this test really wants is an assertion that the data is intact, which `median()` still covers pretty well since any change to the data will likely push the median around.

## Checklist
Delete items not relevant to your PR:
- N/A