### PR TITLE
fix(types): accept Decimal types with zero scale

### DIFF
--- a/types/src/data_types.rs
+++ b/types/src/data_types.rs
@@ -583,9 +583,9 @@ fn parse_decimal(input: &str) -> Result<DataTypeNode, TypesError> {
             })?;
         let precision = parsed[0];
         let scale = parsed[1];
-        if scale < 1 || precision < 1 {
+        if precision == 0 {
             return Err(TypesError::TypeParsingError(format!(
-                "Invalid Decimal format, expected Decimal(P, S) with P > 0 and S > 0, got {input}"
+                "Invalid Decimal format, expected Decimal(P, S) with P > 0, got {input}"
             )));
         }
         if precision < scale {
@@ -1165,6 +1165,10 @@ mod tests {
         assert_eq!(
             DataTypeNode::new("Decimal(42, 8)").unwrap(),
             DataTypeNode::Decimal(42, 8, DecimalType::Decimal256)
+        );
+        assert_eq!(
+            DataTypeNode::new("Decimal(25, 0)").unwrap(),
+            DataTypeNode::Decimal(25, 0, DecimalType::Decimal128)
         );
         assert!(DataTypeNode::new("Decimal").is_err());
         assert!(DataTypeNode::new("Decimal(").is_err());


### PR DESCRIPTION
## Problem

`clickhouse-types` rejects `Decimal(P, 0)` even though zero is a valid ClickHouse Decimal scale. As a result, reading a `RowBinaryWithNamesAndTypes` header fails when it contains a type such as `Decimal(25, 0)`.

The parser required both precision and scale to be greater than zero. Only precision has that constraint; scale may be zero as long as it does not exceed precision.

## Change

- require `P > 0` while allowing `S = 0`
- preserve the existing `P >= S` and maximum-precision checks
- add regression coverage for the reported `Decimal(25, 0)` type

Closes #440.

## Validation

- `cargo fmt --check`
- `cargo test -p clickhouse-types` (42 unit tests and 1 doc test)
