### PR TITLE
fix(native): decode fixed-width tuples structurally

### DIFF
--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -227,9 +227,8 @@ fn type_fixed_width(data_type: &DataTypeNode) -> Option<usize> {
         // Type width determined by metadata that comes before column data.
         DataTypeNode::LowCardinality(_) => None,
         DataTypeNode::Array(_) => None,
-        DataTypeNode::Tuple(types) => types.iter().try_fold(0usize, |total, inner| {
-            total.checked_add(type_fixed_width(inner)?)
-        }),
+        // Tuples are serialized column-by-column and need a structural layout.
+        DataTypeNode::Tuple(_) => None,
         DataTypeNode::Enum(type_, _) => match type_ {
             EnumType::Enum8 => Some(1),
             EnumType::Enum16 => Some(2),

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -23,6 +23,41 @@ async fn mixed_types_1000() {
     mixed_types(1000).await
 }
 
+#[tokio::test]
+async fn fixed_width_tuples() {
+    let client = get_client();
+
+    let mut cursor = client
+        .query(
+            "SELECT
+                tuple(toUInt64(number), toUInt32(number + 1)) AS fixed_tuple,
+                arrayMap(
+                    x -> tuple(toUInt64(x), toUInt32(x + 1)),
+                    range(number)
+                ) AS fixed_tuple_array
+            FROM system.numbers
+            LIMIT 3",
+        )
+        .fetch_native()
+        .unwrap();
+
+    let block = cursor.next().await.unwrap().expect("expected one block");
+
+    let tuples = block["fixed_tuple"]
+        .iter::<(u64, u32)>()
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(tuples, [(0, 1), (1, 2), (2, 3)]);
+
+    let tuple_arrays = block["fixed_tuple_array"]
+        .iter::<Vec<(u64, u32)>>()
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(tuple_arrays, [vec![], vec![(0, 1)], vec![(0, 1), (1, 2)]]);
+}
+
 // NOTE: requires >50GiB RAM on the server, likely because all the strings have to live in memory
 #[ignore]
 #[tokio::test]


### PR DESCRIPTION
## Summary

Native decoding treated a `Tuple` as one fixed-width value when every tuple element had a fixed width. This bypassed the tuple layout and sent the combined bytes through scalar decoding, which rejects tuple types.

Keep tuples on the structural decoding path so each element is read from its own column layout.

The regression test covers both `Tuple(UInt64, UInt32)` and `Array(Tuple(UInt64, UInt32))`.

## Checks

- `cargo test --workspace --lib --all-features`
- `cargo test --test it fixed_width_tuples`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`